### PR TITLE
Refactor SMS Orange integration with delivery tracking and admin API

### DIFF
--- a/src/main/java/commonTasks/dto/NotificationClientDTO.java
+++ b/src/main/java/commonTasks/dto/NotificationClientDTO.java
@@ -24,6 +24,15 @@ public class NotificationClientDTO implements Serializable {
     private String email;
     private String userId;
     private String clientId;
+    private String deliveryStatus;
+
+    public String getDeliveryStatus() {
+        return deliveryStatus;
+    }
+
+    public void setDeliveryStatus(String deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
 
     public String getFullName() {
         return fullName;
@@ -91,6 +100,7 @@ public class NotificationClientDTO implements Serializable {
         this.lastName = client.getStrLASTNAME();
         this.firstName = client.getStrFIRSTNAME();
         this.clientId = client.getLgCLIENTID();
+        this.deliveryStatus = notificationClient.getDeliveryStatus();
     }
 
     public String getEmail() {

--- a/src/main/java/dal/NotificationClient.java
+++ b/src/main/java/dal/NotificationClient.java
@@ -29,7 +29,8 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "notification_client")
 @NamedQueries({
-        @NamedQuery(name = "NotificationClient.findByNotificationId", query = "SELECT o FROM NotificationClient o WHERE o.notification.id=:notificationId")
+        @NamedQuery(name = "NotificationClient.findByNotificationId", query = "SELECT o FROM NotificationClient o WHERE o.notification.id=:notificationId"),
+        @NamedQuery(name = "NotificationClient.findByResourceUrl", query = "SELECT o FROM NotificationClient o WHERE o.resourceUrl=:resourceUrl")
 
 })
 public class NotificationClient implements Serializable {
@@ -50,6 +51,24 @@ public class NotificationClient implements Serializable {
     private Statut statut = Statut.NOT_SEND;
     @Column(name = "sent_at")
     private LocalDateTime sentAt;
+    /** URL de la ressource SMS retournée par Orange (suivi / Delivery Receipt). */
+    @Column(name = "resource_url", length = 500)
+    private String resourceUrl;
+    /**
+     * Statut de livraison Orange : ACCEPTED_BY_ORANGE, DELIVERED_TO_TERMINAL,
+     * DELIVERY_IMPOSSIBLE, DELIVERY_UNCERTAIN, MESSAGE_WAITING...
+     */
+    @Column(name = "delivery_status", length = 40)
+    private String deliveryStatus;
+    /** Code d'erreur Orange (messageId : SVCxxxx / POLxxxx) ou HTTP_xxx. */
+    @Column(name = "error_code", length = 60)
+    private String errorCode;
+    /** Libellé d'erreur lisible. */
+    @Column(name = "error_message", length = 500)
+    private String errorMessage;
+    /** Dernier code HTTP renvoyé par Orange pour ce destinataire. */
+    @Column(name = "last_http_status")
+    private Integer lastHttpStatus;
 
     public Statut getStatut() {
         return statut;
@@ -65,6 +84,46 @@ public class NotificationClient implements Serializable {
 
     public void setSentAt(LocalDateTime sentAt) {
         this.sentAt = sentAt;
+    }
+
+    public String getResourceUrl() {
+        return resourceUrl;
+    }
+
+    public void setResourceUrl(String resourceUrl) {
+        this.resourceUrl = resourceUrl;
+    }
+
+    public String getDeliveryStatus() {
+        return deliveryStatus;
+    }
+
+    public void setDeliveryStatus(String deliveryStatus) {
+        this.deliveryStatus = deliveryStatus;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public Integer getLastHttpStatus() {
+        return lastHttpStatus;
+    }
+
+    public void setLastHttpStatus(Integer lastHttpStatus) {
+        this.lastHttpStatus = lastHttpStatus;
     }
 
     public TClient getClient() {

--- a/src/main/java/filter/AuthenticationFilter.java
+++ b/src/main/java/filter/AuthenticationFilter.java
@@ -27,7 +27,7 @@ import util.Constant;
 @Provider
 public class AuthenticationFilter implements ContainerRequestFilter {
 
-    private static final Set<String> SKIP_PATHS = Set.of("v1/user/auth", "v1/user/logout", "v1/ws/", "v1/valorisation",
+    private static final Set<String> SKIP_PATHS = Set.of("v1/sms/dr-callback", "v1/user/auth", "v1/user/logout", "v1/ws/", "v1/valorisation",
             "v1/valorisation/all", "v1/ca-comptant", "v1/ca-credit", "v1/reglements", "v1/factures", "v1/fournisseurs",
             "v1/achats-fournisseurs", "v1/stock", "v1/tierspayants", "v1/avoirs-fournisseurs", "v1/whareouse-vno",
             "v1/whareouse-maxmin", "v1/ca-all", "v1/checkproduit", "v1/ws/ca-achats-ventes", "v1/ws/inventaires",

--- a/src/main/java/job/NotificationScheduledService.java
+++ b/src/main/java/job/NotificationScheduledService.java
@@ -1,18 +1,14 @@
 package job;
 
 import dal.Notification;
-import dal.NotificationClient;
-import dal.SmsToken;
 import dal.TParameters;
 import dal.enumeration.Canal;
 import dal.enumeration.Statut;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.Asynchronous;
@@ -24,19 +20,8 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import javax.persistence.TypedQuery;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
 import rest.service.NotificationService;
-import util.AppParameters;
+import rest.service.SmsService;
 import util.Constant;
 
 /**
@@ -53,7 +38,7 @@ public class NotificationScheduledService {
     @Inject
     private NotificationService notificationService;
     @EJB
-    private NotificationScheduledService self;
+    private SmsService smsService;
 
     @Asynchronous
     public void sendPendingEmailsAsync() {
@@ -67,7 +52,10 @@ public class NotificationScheduledService {
             List<Notification> notifications = findAllByCanal();
             for (Notification notification : notifications) {
                 try {
-                    sendSMS(notification);
+                    // Délégation à SmsService : envoi à TOUS les destinataires,
+                    // suivi par client (resourceURL, code d'erreur) et logs unifiés.
+                    // Token et persistance gérés de façon centralisée par SmsImpl.
+                    smsService.sendSMSById(notification.getId());
                 } catch (Exception e) {
                     LOG.log(Level.SEVERE, "", e);
                 }
@@ -76,153 +64,6 @@ public class NotificationScheduledService {
 
         }
 
-    }
-
-    private void sendSMS(Notification notification) {
-        Client client = ClientBuilder.newClient();
-        AppParameters sp = AppParameters.getInstance();
-        List<NotificationClient> toClients = findNotificationClients(notification);
-        String address = null;
-        if (!toClients.isEmpty()) { // a revoir pour les envois multiples
-            address = toClients.get(0).getClient().getStrADRESSE();
-        }
-        if (StringUtils.isEmpty(address)) {
-            address = sp.mobile;
-        }
-        JSONObject jSONObject = new JSONObject();
-        JSONObject outboundSMSMessageRequest = new JSONObject();
-        outboundSMSMessageRequest.put("address", "tel:+225" + address);
-        outboundSMSMessageRequest.put("senderAddress", sp.senderAddress);
-        JSONObject outboundSMSTextMessage = new JSONObject();
-        outboundSMSTextMessage.put("message", notification.getMessage());
-        outboundSMSMessageRequest.put("outboundSMSTextMessage", outboundSMSTextMessage);
-        jSONObject.put("outboundSMSMessageRequest", outboundSMSMessageRequest);
-        WebTarget myResource = client.target(sp.pathsmsapisendmessageurl);
-        Response response = myResource.request().header("Authorization", "Bearer ".concat(getAccessToken()))
-                .post(Entity.entity(jSONObject.toString(), MediaType.APPLICATION_JSON_TYPE));
-        LOG.log(Level.INFO, "sendSMS >>> {0} {1} {2}",
-                new Object[] { response.getStatus(), response.readEntity(String.class), address });
-        if (response.getStatus() == 201) {
-            notification.setStatut(Statut.SENT);
-
-        } else {
-            notification.setNumberAttempt(notification.getNumberAttempt() + 1);
-            if (notification.getNumberAttempt() >= 3) {
-                notification.setModfiedAt(LocalDateTime.now());
-                notification.setStatut(Statut.LOCK);
-            }
-        }
-
-        LOG.log(Level.INFO, null, notification.getStatut());
-        self.mergeNotification(notification);
-
-    }
-
-    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void mergeNotification(Notification notification) {
-        em.merge(notification);
-    }
-
-    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void persistSmsToken(SmsToken smsToken) {
-        em.persist(smsToken);
-    }
-
-    @TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
-    public void mergeSmsToken(SmsToken smsToken) {
-        em.merge(smsToken);
-    }
-
-    private List<NotificationClient> findNotificationClients(Notification n) {
-        try {
-            TypedQuery<NotificationClient> q = em.createNamedQuery("NotificationClient.findByNotificationId",
-                    NotificationClient.class);
-            q.setParameter("notificationId", n.getId());
-            return q.getResultList();
-        } catch (Exception e) {
-            LOG.log(Level.SEVERE, null, e);
-            return Collections.emptyList();
-        }
-    }
-
-    private String getAccessToken() {
-
-        SmsToken smsToken = getOrupdateSmsToken();
-
-        return Objects.nonNull(smsToken) ? smsToken.getAccessToken() : null;
-
-    }
-
-    private SmsToken getOrupdateSmsToken() {
-        SmsToken smsToken = getSmsToken();
-        if (smsToken == null) {
-            JSONObject json = findAccessToken();
-            if (json.has("success") && json.getBoolean("success")) {
-                smsToken = new SmsToken();
-                smsToken.setId("sms");
-                JSONObject data = json.getJSONObject("data");
-                smsToken.setAccessToken(data.getString("access_token"));
-                smsToken.setExpiresIn(data.getInt("expires_in"));
-                smsToken.setHeader("Basic ZkphT2xKZ3dVMmdnY1JXbUlsYlU5czdqWTh0YnNSeTg6U01FNTVndFlkdjJoNlkwUQ==");
-                smsToken.setCreateDate(LocalDateTime.now());
-
-                self.persistSmsToken(smsToken);
-            }
-
-        } else {
-            if (smsToken.getCreateDate()
-                    .isBefore(LocalDateTime.now().minus(smsToken.getExpiresIn(), ChronoUnit.SECONDS))) {
-                JSONObject json = findAccessToken();
-                if (json.has("success") && json.getBoolean("success")) {
-                    JSONObject data = json.getJSONObject("data");
-                    smsToken.setAccessToken(data.getString("access_token"));
-                    smsToken.setExpiresIn(data.getInt("expires_in"));
-                    smsToken.setCreateDate(LocalDateTime.now());
-                    self.mergeSmsToken(smsToken);
-                }
-            }
-        }
-        return smsToken;
-    }
-
-    private SmsToken getSmsToken() {
-        try {
-            return em.find(SmsToken.class, "sms");
-
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    private JSONObject findAccessToken() {
-        try {
-            Client client = ClientBuilder.newClient();
-            AppParameters sp = AppParameters.getInstance();
-            MultivaluedMap<String, String> formdata = new MultivaluedHashMap<>();
-            formdata.add("grant_type", Constant.GRANT_TYPE);
-            WebTarget myResource = client.target(sp.pathsmsapitokenendpoint);
-            Response response = myResource.request(MediaType.APPLICATION_JSON)
-                    .header("Authorization", StringUtils.isNotEmpty(getBasicHeader()) ? getBasicHeader() : sp.header)
-                    .post(Entity.entity(formdata, MediaType.APPLICATION_FORM_URLENCODED), Response.class);
-            if (response.getStatus() == 200) {
-                return new JSONObject().put("success", true).put("data",
-                        new JSONObject(response.readEntity(String.class)));
-            }
-
-            return new JSONObject().put("success", false).put("msg", "Le token n'a pad pu être géneré ");
-        } catch (JSONException e) {
-            LOG.log(Level.SEVERE, null, e);
-            return new JSONObject().put("success", false).put("msg", "Le token n'a pad pu être géneré ");
-        }
-    }
-
-    private String getBasicHeader() {
-        try {
-            return em.find(SmsToken.class, "sms").getHeader();
-
-        } catch (Exception e) {
-            return "";
-        }
     }
 
     private List<Notification> findAllByCanal() {

--- a/src/main/java/rest/NotificationResource.java
+++ b/src/main/java/rest/NotificationResource.java
@@ -64,16 +64,9 @@ public class NotificationResource {
         if (tu == null) {
             return Response.ok().entity(ResultFactory.getFailResult(Constant.DECONNECTED_MESSAGE)).build();
         }
-        String statut = smsService.resendSMSById(id);
-        if (statut == null) {
-            return Response.ok().entity(ResultFactory.getFailResult("Notification introuvable")).build();
-        }
-        boolean accepted = "SENT".equals(statut);
-        JSONObject result = new JSONObject()
-                .put("success", accepted)
-                .put("statut", statut)
-                .put("msg", accepted ? "SMS accepté par Orange (201)"
-                        : "Non accepté par Orange - statut: " + statut + ". Voir les logs serveur pour le code d'erreur.");
+        JSONObject result = smsService.resendSMSById(id);
+        // On expose le message d'action au front via "msg".
+        result.put("msg", result.optString("userMessage", "Renvoi traité."));
         return Response.ok().entity(result.toString()).build();
     }
 

--- a/src/main/java/rest/NotificationResource.java
+++ b/src/main/java/rest/NotificationResource.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.CacheControl;
@@ -53,6 +54,27 @@ public class NotificationResource {
         }
         this.smsService.sendSMS(notificationService.buildNotification(notification, tu));
         return Response.ok().entity(ResultFactory.getSuccessResultMsg()).build();
+    }
+
+    @POST
+    @Path("{id}/resend")
+    public Response resendSmsNotification(@PathParam("id") String id) {
+        HttpSession hs = servletRequest.getSession();
+        TUser tu = (TUser) hs.getAttribute(Constant.AIRTIME_USER);
+        if (tu == null) {
+            return Response.ok().entity(ResultFactory.getFailResult(Constant.DECONNECTED_MESSAGE)).build();
+        }
+        String statut = smsService.resendSMSById(id);
+        if (statut == null) {
+            return Response.ok().entity(ResultFactory.getFailResult("Notification introuvable")).build();
+        }
+        boolean accepted = "SENT".equals(statut);
+        JSONObject result = new JSONObject()
+                .put("success", accepted)
+                .put("statut", statut)
+                .put("msg", accepted ? "SMS accepté par Orange (201)"
+                        : "Non accepté par Orange - statut: " + statut + ". Voir les logs serveur pour le code d'erreur.");
+        return Response.ok().entity(result.toString()).build();
     }
 
     @GET

--- a/src/main/java/rest/SmsResource.java
+++ b/src/main/java/rest/SmsResource.java
@@ -74,6 +74,26 @@ public class SmsResource {
         return Response.ok(smsAdminService.createDeliveryReceiptSubscription().toString()).build();
     }
 
+    /** URL de callback DR actuelle (et sa source : paramètre base ou fichier). */
+    @GET
+    @Path("dr-callback-url")
+    public Response getDrCallbackUrl() {
+        return Response.ok(smsAdminService.getCallbackUrlInfo().toString()).build();
+    }
+
+    /** Enregistre l'URL de callback DR dans les paramètres (base). */
+    @POST
+    @Path("dr-callback-url")
+    public Response saveDrCallbackUrl(String body) {
+        String url = "";
+        try {
+            url = new org.json.JSONObject(body).optString("url", "");
+        } catch (Exception ignore) {
+            // corps vide ou invalide
+        }
+        return Response.ok(smsAdminService.saveCallbackUrl(url).toString()).build();
+    }
+
     /** Supprime une souscription Delivery Receipt. */
     @DELETE
     @Path("dr-subscriptions/{id}")

--- a/src/main/java/rest/SmsResource.java
+++ b/src/main/java/rest/SmsResource.java
@@ -1,0 +1,93 @@
+package rest;
+
+import javax.ejb.EJB;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+import rest.service.SmsAdminService;
+import rest.service.SmsService;
+
+/**
+ * Endpoints SMS Orange : consultation du solde / statistiques / achats,
+ * gestion des souscriptions Delivery Receipt (DR) et réception du callback DR.
+ *
+ * L'authentification des endpoints de consultation/gestion est assurée par le
+ * {@code AuthenticationFilter} global ; seul {@code dr-callback} est exempté
+ * (il est appelé par Orange, sans session) via {@code SKIP_PATHS}.
+ *
+ * @author koben
+ */
+@Path("v1/sms")
+@Produces("application/json")
+@Consumes("application/json")
+public class SmsResource {
+
+    @EJB
+    private SmsAdminService smsAdminService;
+    @EJB
+    private SmsService smsService;
+
+    /** Solde / contrats SMS (bundle restant, expiration). */
+    @GET
+    @Path("balance")
+    public Response balance() {
+        return Response.ok(smsAdminService.getContracts().toString()).build();
+    }
+
+    /** Statistiques d'utilisation SMS. */
+    @GET
+    @Path("statistics")
+    public Response statistics() {
+        return Response.ok(smsAdminService.getStatistics().toString()).build();
+    }
+
+    /** Historique des achats SMS. */
+    @GET
+    @Path("purchase-orders")
+    public Response purchaseOrders() {
+        return Response.ok(smsAdminService.getPurchaseOrders().toString()).build();
+    }
+
+    /** Liste les souscriptions Delivery Receipt. */
+    @GET
+    @Path("dr-subscriptions")
+    public Response listDrSubscriptions() {
+        return Response.ok(smsAdminService.getDeliveryReceiptSubscriptions().toString()).build();
+    }
+
+    /** Crée une souscription Delivery Receipt (utilise l'URL de callback configurée). */
+    @POST
+    @Path("dr-subscriptions")
+    public Response createDrSubscription() {
+        return Response.ok(smsAdminService.createDeliveryReceiptSubscription().toString()).build();
+    }
+
+    /** Supprime une souscription Delivery Receipt. */
+    @DELETE
+    @Path("dr-subscriptions/{id}")
+    public Response deleteDrSubscription(@PathParam("id") String id) {
+        return Response.ok(smsAdminService.deleteDeliveryReceiptSubscription(id).toString()).build();
+    }
+
+    /**
+     * Callback appelé par Orange pour notifier le statut de livraison d'un SMS.
+     * PUBLIC (pas de session) : on acquitte systématiquement (204) pour éviter
+     * les ré-émissions côté Orange.
+     */
+    @POST
+    @Path("dr-callback")
+    public Response deliveryReceiptCallback(String payload) {
+        try {
+            smsService.handleDeliveryReceipt(payload);
+        } catch (Exception ignore) {
+            // on acquitte quand même
+        }
+        return Response.noContent().build();
+    }
+
+}

--- a/src/main/java/rest/SmsResource.java
+++ b/src/main/java/rest/SmsResource.java
@@ -32,11 +32,18 @@ public class SmsResource {
     @EJB
     private SmsService smsService;
 
-    /** Solde / contrats SMS (bundle restant, expiration). */
+    /** Solde / contrats SMS (bundle restant, expiration) - réponse Orange brute. */
     @GET
     @Path("balance")
     public Response balance() {
         return Response.ok(smsAdminService.getContracts().toString()).build();
+    }
+
+    /** Solde SMS résumé et prêt à afficher (total d'unités + détail par contrat). */
+    @GET
+    @Path("solde")
+    public Response solde() {
+        return Response.ok(smsAdminService.getBalanceSummary().toString()).build();
     }
 
     /** Statistiques d'utilisation SMS. */

--- a/src/main/java/rest/SmsResource.java
+++ b/src/main/java/rest/SmsResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import rest.service.SmsAdminService;
 import rest.service.SmsService;
@@ -81,17 +82,20 @@ public class SmsResource {
         return Response.ok(smsAdminService.getCallbackUrlInfo().toString()).build();
     }
 
-    /** Enregistre l'URL de callback DR dans les paramètres (base). */
+    /** Enregistre l'URL et/ou le jeton secret du callback DR dans les paramètres. */
     @POST
     @Path("dr-callback-url")
     public Response saveDrCallbackUrl(String body) {
-        String url = "";
+        String url = null;
+        String secret = null;
         try {
-            url = new org.json.JSONObject(body).optString("url", "");
+            org.json.JSONObject json = new org.json.JSONObject(body);
+            url = json.has("url") ? json.optString("url", "") : null;
+            secret = json.has("secret") ? json.optString("secret", "") : null;
         } catch (Exception ignore) {
             // corps vide ou invalide
         }
-        return Response.ok(smsAdminService.saveCallbackUrl(url).toString()).build();
+        return Response.ok(smsAdminService.saveCallbackConfig(url, secret).toString()).build();
     }
 
     /** Supprime une souscription Delivery Receipt. */
@@ -108,7 +112,11 @@ public class SmsResource {
      */
     @POST
     @Path("dr-callback")
-    public Response deliveryReceiptCallback(String payload) {
+    public Response deliveryReceiptCallback(@QueryParam("key") String key, String payload) {
+        if (!smsAdminService.isCallbackKeyValid(key)) {
+            // Jeton absent/incorrect : on refuse sans traiter.
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
         try {
             smsService.handleDeliveryReceipt(payload);
         } catch (Exception ignore) {

--- a/src/main/java/rest/service/SmsAdminService.java
+++ b/src/main/java/rest/service/SmsAdminService.java
@@ -34,13 +34,22 @@ public interface SmsAdminService {
     JSONObject createDeliveryReceiptSubscription();
 
     /**
-     * URL de callback DR actuellement utilisée et sa source :
-     * {@code {url, source}} où source = "parametre" (base) ou "fichier".
+     * URL de callback DR et configuration de protection :
+     * {@code {url, source, secret, protected}}.
      */
     JSONObject getCallbackUrlInfo();
 
-    /** Enregistre l'URL de callback DR dans les paramètres (base). */
-    JSONObject saveCallbackUrl(String url);
+    /**
+     * Enregistre l'URL et/ou le jeton secret du callback DR dans les paramètres.
+     * Un argument {@code null} laisse le paramètre correspondant inchangé.
+     */
+    JSONObject saveCallbackConfig(String url, String secret);
+
+    /**
+     * Vérifie le jeton fourni par l'appelant du callback. Retourne true si aucun
+     * secret n'est configuré (protection désactivée) ou si le jeton correspond.
+     */
+    boolean isCallbackKeyValid(String providedKey);
 
     /** Liste les souscriptions DR existantes. */
     JSONObject getDeliveryReceiptSubscriptions();

--- a/src/main/java/rest/service/SmsAdminService.java
+++ b/src/main/java/rest/service/SmsAdminService.java
@@ -18,6 +18,12 @@ public interface SmsAdminService {
     /** Contrats SMS (solde restant, date d'expiration des bundles). */
     JSONObject getContracts();
 
+    /**
+     * Résumé du solde SMS, prêt à afficher :
+     * {@code {success, totalUnits, found, items:[{units, country, service, expiration}]}}.
+     */
+    JSONObject getBalanceSummary();
+
     /** Statistiques d'utilisation SMS. */
     JSONObject getStatistics();
 

--- a/src/main/java/rest/service/SmsAdminService.java
+++ b/src/main/java/rest/service/SmsAdminService.java
@@ -33,6 +33,15 @@ public interface SmsAdminService {
     /** Crée une souscription aux Delivery Receipts (nécessite l'URL de callback). */
     JSONObject createDeliveryReceiptSubscription();
 
+    /**
+     * URL de callback DR actuellement utilisée et sa source :
+     * {@code {url, source}} où source = "parametre" (base) ou "fichier".
+     */
+    JSONObject getCallbackUrlInfo();
+
+    /** Enregistre l'URL de callback DR dans les paramètres (base). */
+    JSONObject saveCallbackUrl(String url);
+
     /** Liste les souscriptions DR existantes. */
     JSONObject getDeliveryReceiptSubscriptions();
 

--- a/src/main/java/rest/service/SmsAdminService.java
+++ b/src/main/java/rest/service/SmsAdminService.java
@@ -1,0 +1,36 @@
+package rest.service;
+
+import javax.ejb.Local;
+import org.json.JSONObject;
+
+/**
+ * Accès aux opérations d'administration de l'API SMS Orange : consultation du
+ * solde / des contrats, des statistiques, des bons d'achat, et gestion des
+ * souscriptions aux Delivery Receipts (DR).
+ *
+ * Réf : https://developer.orange.com/apis/sms-ci/api-reference
+ *
+ * @author koben
+ */
+@Local
+public interface SmsAdminService {
+
+    /** Contrats SMS (solde restant, date d'expiration des bundles). */
+    JSONObject getContracts();
+
+    /** Statistiques d'utilisation SMS. */
+    JSONObject getStatistics();
+
+    /** Historique des achats / bons de commande SMS. */
+    JSONObject getPurchaseOrders();
+
+    /** Crée une souscription aux Delivery Receipts (nécessite l'URL de callback). */
+    JSONObject createDeliveryReceiptSubscription();
+
+    /** Liste les souscriptions DR existantes. */
+    JSONObject getDeliveryReceiptSubscriptions();
+
+    /** Supprime une souscription DR. */
+    JSONObject deleteDeliveryReceiptSubscription(String subscriptionId);
+
+}

--- a/src/main/java/rest/service/SmsService.java
+++ b/src/main/java/rest/service/SmsService.java
@@ -35,6 +35,13 @@ public interface SmsService {
      */
     void sendSMSById(String notificationId);
 
+    /**
+     * Renvoi manuel forcé d'une notification (même si déjà SENT), pour les tests
+     * et les corrections. Retourne le statut résultant ("SENT", "NOT_SEND",
+     * "LOCK") ou null si la notification est introuvable.
+     */
+    String resendSMSById(String notificationId);
+
     /** Retourne un token d'accès Orange valide (rafraîchi si expiré), ou null. */
     String getValidAccessToken();
 

--- a/src/main/java/rest/service/SmsService.java
+++ b/src/main/java/rest/service/SmsService.java
@@ -22,4 +22,29 @@ public interface SmsService {
 
     void sendSMS(String content);
 
+    /**
+     * Envoi immédiat et asynchrone d'une notification SMS à partir de son
+     * identifiant (rechargée dans une transaction dédiée). Utilisé pour ne plus
+     * attendre le job planifié (ex. SMS de disponibilité d'avoir).
+     */
+    void sendSMSByNotificationIdAsync(String notificationId);
+
+    /**
+     * Envoi synchrone d'une notification SMS par identifiant (rechargée puis
+     * envoyée à tous ses destinataires). Utilisé par le job planifié.
+     */
+    void sendSMSById(String notificationId);
+
+    /** Retourne un token d'accès Orange valide (rafraîchi si expiré), ou null. */
+    String getValidAccessToken();
+
+    /**
+     * Traite un Delivery Receipt Orange (callback) et met à jour le statut de
+     * livraison du destinataire concerné.
+     *
+     * @param rawPayload corps JSON reçu d'Orange
+     * @return true si un destinataire a été mis à jour
+     */
+    boolean handleDeliveryReceipt(String rawPayload);
+
 }

--- a/src/main/java/rest/service/SmsService.java
+++ b/src/main/java/rest/service/SmsService.java
@@ -37,10 +37,13 @@ public interface SmsService {
 
     /**
      * Renvoi manuel forcé d'une notification (même si déjà SENT), pour les tests
-     * et les corrections. Retourne le statut résultant ("SENT", "NOT_SEND",
-     * "LOCK") ou null si la notification est introuvable.
+     * et les corrections.
+     *
+     * @return un JSON {@code {success, statut, code, orangeMessage, userMessage}}.
+     *         {@code success=false} et {@code statut=null} si la notification est
+     *         introuvable. {@code userMessage} est un message d'action lisible.
      */
-    String resendSMSById(String notificationId);
+    JSONObject resendSMSById(String notificationId);
 
     /** Retourne un token d'accès Orange valide (rafraîchi si expiré), ou null. */
     String getValidAccessToken();

--- a/src/main/java/rest/service/impl/CommandeServiceImpl.java
+++ b/src/main/java/rest/service/impl/CommandeServiceImpl.java
@@ -41,6 +41,7 @@ import java.io.InputStreamReader;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -96,6 +97,7 @@ import rest.service.MvtProduitService;
 import rest.service.NotificationService;
 import rest.service.OrderService;
 import rest.service.SessionHelperService;
+import rest.service.SmsService;
 import rest.service.TransactionService;
 import util.Constant;
 import util.DateCommonUtils;
@@ -129,6 +131,8 @@ public class CommandeServiceImpl implements CommandeService {
     private EntityManager em;
     @EJB
     private NotificationService notificationService;
+    @EJB
+    private SmsService smsService;
     @EJB
     private SessionHelperService sessionHelperService;
     @EJB
@@ -326,6 +330,8 @@ public class CommandeServiceImpl implements CommandeService {
             Map<TClient, List<TPreenregistrementDetail>> map = avoirs0.stream()
                     .filter(e -> Objects.nonNull(e.getLgPREENREGISTREMENTID().getClient()))
                     .collect(Collectors.groupingBy(e -> e.getLgPREENREGISTREMENTID().getClient()));
+            List<String> avoirNotificationIds = new ArrayList<>();
+            boolean immediateAvoirSms = isImmediateAvoirSmsEnabled();
             map.forEach((k, v) -> {
                 if (k != null) {
                     StringBuilder sb = new StringBuilder();
@@ -349,12 +355,28 @@ public class CommandeServiceImpl implements CommandeService {
                             user.getStrFIRSTNAME() + " " + user.getStrLASTNAME());
                     donneesMap.put(NotificationUtils.MVT_DATE.getId(), DateCommonUtils.formatCurrentDate());
 
-                    createNotification(sb.toString(), TypeNotification.AVOIR_PRODUIT, user, donneesMap,
-                            bonLivraison.getLgBONLIVRAISONID(), k);
+                    Notification avoirNotification = createNotification(sb.toString(), TypeNotification.AVOIR_PRODUIT,
+                            user, donneesMap, bonLivraison.getLgBONLIVRAISONID(), k);
+                    if (avoirNotification != null) {
+                        avoirNotificationIds.add(avoirNotification.getId());
+                    }
                 }
 
             });
             userTransaction.commit();
+
+            // Envoi immédiat des SMS d'avoir (après commit pour que la notification
+            // soit persistée). Asynchrone : n'impacte pas la réponse de l'entrée en
+            // stock. Le job planifié reste le filet de rattrapage en cas d'échec.
+            if (immediateAvoirSms) {
+                for (String avoirNotificationId : avoirNotificationIds) {
+                    try {
+                        smsService.sendSMSByNotificationIdAsync(avoirNotificationId);
+                    } catch (Exception e) {
+                        LOG.log(Level.SEVERE, "Echec declenchement envoi immediat avoir " + avoirNotificationId, e);
+                    }
+                }
+            }
 
         } catch (IllegalStateException | NumberFormatException | SecurityException | HeuristicMixedException
                 | HeuristicRollbackException | NotSupportedException | RollbackException | SystemException
@@ -1090,7 +1112,7 @@ public class CommandeServiceImpl implements CommandeService {
         }
     }
 
-    private void createNotification(String msg, TypeNotification typeNotification, TUser user,
+    private Notification createNotification(String msg, TypeNotification typeNotification, TUser user,
             Map<String, Object> donneesMap, String entityRef, TClient client) {
         try {
 
@@ -1103,10 +1125,22 @@ public class CommandeServiceImpl implements CommandeService {
                 notification.addNotificationClients(notificationClient);
             }
             notificationService.save(notification);
+            return notification;
         } catch (Exception ex) {
             LOG.log(Level.SEVERE, null, ex);
         }
+        return null;
 
+    }
+
+    /** Vrai si l'envoi immédiat des SMS d'avoir est activé (param KEY_SMS_AVOIR_IMMEDIAT). */
+    private boolean isImmediateAvoirSmsEnabled() {
+        try {
+            TParameters p = em.find(TParameters.class, Constant.KEY_SMS_AVOIR_IMMEDIAT);
+            return p != null && "1".equals(p.getStrVALUE().trim());
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     private List<TLot> getLot(String idProduit, String bonRef) {

--- a/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
+++ b/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
@@ -1,6 +1,8 @@
 package rest.service.impl;
 
 import dal.TParameters;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,8 +55,16 @@ public class SmsAdminServiceImpl implements SmsAdminService {
     }
 
     private String readCallbackUrlParam() {
+        return readParam(util.Constant.KEY_SMS_DR_CALLBACK_URL);
+    }
+
+    private String readCallbackSecret() {
+        return readParam(util.Constant.KEY_SMS_DR_CALLBACK_SECRET);
+    }
+
+    private String readParam(String key) {
         try {
-            TParameters p = em.find(TParameters.class, util.Constant.KEY_SMS_DR_CALLBACK_URL);
+            TParameters p = em.find(TParameters.class, key);
             return p != null ? p.getStrVALUE() : null;
         } catch (Exception e) {
             return null;
@@ -73,36 +83,66 @@ public class SmsAdminServiceImpl implements SmsAdminService {
             url = sp.smsdrcallbackurl;
             source = "fichier";
         }
+        String secret = StringUtils.trimToEmpty(readCallbackSecret());
         return new JSONObject()
                 .put("success", true)
                 .put("url", url != null ? url : "")
-                .put("source", source);
+                .put("source", source)
+                .put("secret", secret)
+                .put("protected", StringUtils.isNotBlank(secret));
     }
 
     @Override
-    public JSONObject saveCallbackUrl(String url) {
+    public JSONObject saveCallbackConfig(String url, String secret) {
         try {
-            String value = StringUtils.trimToEmpty(url);
-            TParameters p = em.find(TParameters.class, util.Constant.KEY_SMS_DR_CALLBACK_URL);
-            if (p == null) {
-                p = new TParameters(util.Constant.KEY_SMS_DR_CALLBACK_URL);
-                p.setStrDESCRIPTION("URL publique appelee par Orange pour les accuses de reception SMS");
-                p.setStrTYPE("SYSTEM");
-                p.setStrSTATUT("enable");
-                p.setDtCREATED(new Date());
-                p.setStrVALUE(value);
-                em.persist(p);
-            } else {
-                p.setStrVALUE(value);
-                p.setDtUPDATED(new Date());
-                em.merge(p);
+            if (url != null) {
+                upsertParam(util.Constant.KEY_SMS_DR_CALLBACK_URL, StringUtils.trimToEmpty(url),
+                        "URL publique appelee par Orange pour les accuses de reception SMS");
             }
-            return new JSONObject().put("success", true).put("url", value)
-                    .put("msg", "URL de callback DR enregistrée.");
+            if (secret != null) {
+                upsertParam(util.Constant.KEY_SMS_DR_CALLBACK_SECRET, StringUtils.trimToEmpty(secret),
+                        "Jeton secret du callback DR (parametre ?key=)");
+            }
+            return new JSONObject().put("success", true).put("msg", "Configuration du callback DR enregistrée.");
         } catch (Exception e) {
-            LOG.log(Level.SEVERE, "Echec enregistrement URL callback DR", e);
-            return new JSONObject().put("success", false).put("msg", "Echec de l'enregistrement de l'URL.");
+            LOG.log(Level.SEVERE, "Echec enregistrement configuration callback DR", e);
+            return new JSONObject().put("success", false).put("msg", "Echec de l'enregistrement.");
         }
+    }
+
+    private void upsertParam(String key, String value, String description) {
+        TParameters p = em.find(TParameters.class, key);
+        if (p == null) {
+            p = new TParameters(key);
+            p.setStrDESCRIPTION(description);
+            p.setStrTYPE("SYSTEM");
+            p.setStrSTATUT("enable");
+            p.setDtCREATED(new Date());
+            p.setStrVALUE(value);
+            em.persist(p);
+        } else {
+            p.setStrVALUE(value);
+            p.setDtUPDATED(new Date());
+            em.merge(p);
+        }
+    }
+
+    /** Ajoute ?key=secret (ou &key=) à l'URL de callback si un secret est défini. */
+    private String appendSecret(String url, String secret) {
+        if (StringUtils.isBlank(secret)) {
+            return url;
+        }
+        String encoded = URLEncoder.encode(secret.trim(), StandardCharsets.UTF_8);
+        return url + (url.contains("?") ? "&" : "?") + "key=" + encoded;
+    }
+
+    @Override
+    public boolean isCallbackKeyValid(String providedKey) {
+        String secret = StringUtils.trimToEmpty(readCallbackSecret());
+        if (StringUtils.isBlank(secret)) {
+            return true; // protection désactivée
+        }
+        return secret.equals(StringUtils.trimToEmpty(providedKey));
     }
 
     @Override
@@ -206,7 +246,7 @@ public class SmsAdminServiceImpl implements SmsAdminService {
         Client client = ClientBuilder.newClient();
         try {
             JSONObject callbackReference = new JSONObject()
-                    .put("notifyURL", callbackUrl);
+                    .put("notifyURL", appendSecret(callbackUrl, readCallbackSecret()));
             JSONObject subscription = new JSONObject()
                     .put("callbackReference", callbackReference);
             JSONObject body = new JSONObject()

--- a/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
+++ b/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
@@ -1,9 +1,13 @@
 package rest.service.impl;
 
+import dal.TParameters;
+import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
@@ -31,8 +35,75 @@ public class SmsAdminServiceImpl implements SmsAdminService {
 
     private static final Logger LOG = Logger.getLogger(SmsAdminServiceImpl.class.getName());
     private final AppParameters sp = AppParameters.getInstance();
+    @PersistenceContext(unitName = "JTA_UNIT")
+    private EntityManager em;
     @EJB
     private SmsService smsService;
+
+    /**
+     * URL de callback DR effective : paramètre en base si renseigné, sinon
+     * valeur du fichier dicisms.properties.
+     */
+    private String resolveCallbackUrl() {
+        String fromDb = readCallbackUrlParam();
+        if (StringUtils.isNotBlank(fromDb)) {
+            return fromDb.trim();
+        }
+        return sp.smsdrcallbackurl;
+    }
+
+    private String readCallbackUrlParam() {
+        try {
+            TParameters p = em.find(TParameters.class, util.Constant.KEY_SMS_DR_CALLBACK_URL);
+            return p != null ? p.getStrVALUE() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    @Override
+    public JSONObject getCallbackUrlInfo() {
+        String fromDb = readCallbackUrlParam();
+        String url;
+        String source;
+        if (StringUtils.isNotBlank(fromDb)) {
+            url = fromDb.trim();
+            source = "parametre";
+        } else {
+            url = sp.smsdrcallbackurl;
+            source = "fichier";
+        }
+        return new JSONObject()
+                .put("success", true)
+                .put("url", url != null ? url : "")
+                .put("source", source);
+    }
+
+    @Override
+    public JSONObject saveCallbackUrl(String url) {
+        try {
+            String value = StringUtils.trimToEmpty(url);
+            TParameters p = em.find(TParameters.class, util.Constant.KEY_SMS_DR_CALLBACK_URL);
+            if (p == null) {
+                p = new TParameters(util.Constant.KEY_SMS_DR_CALLBACK_URL);
+                p.setStrDESCRIPTION("URL publique appelee par Orange pour les accuses de reception SMS");
+                p.setStrTYPE("SYSTEM");
+                p.setStrSTATUT("enable");
+                p.setDtCREATED(new Date());
+                p.setStrVALUE(value);
+                em.persist(p);
+            } else {
+                p.setStrVALUE(value);
+                p.setDtUPDATED(new Date());
+                em.merge(p);
+            }
+            return new JSONObject().put("success", true).put("url", value)
+                    .put("msg", "URL de callback DR enregistrée.");
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Echec enregistrement URL callback DR", e);
+            return new JSONObject().put("success", false).put("msg", "Echec de l'enregistrement de l'URL.");
+        }
+    }
 
     @Override
     public JSONObject getContracts() {
@@ -123,8 +194,10 @@ public class SmsAdminServiceImpl implements SmsAdminService {
 
     @Override
     public JSONObject createDeliveryReceiptSubscription() {
-        if (StringUtils.isBlank(sp.smsdrcallbackurl)) {
-            return error("L'URL de callback DR (smsdrcallbackurl) n'est pas configurée", 0, null);
+        String callbackUrl = resolveCallbackUrl();
+        if (StringUtils.isBlank(callbackUrl)) {
+            return error("L'URL de callback DR n'est pas configurée (paramètre KEY_SMS_DR_CALLBACK_URL "
+                    + "ou smsdrcallbackurl dans dicisms.properties)", 0, null);
         }
         String token = smsService.getValidAccessToken();
         if (StringUtils.isBlank(token)) {
@@ -133,7 +206,7 @@ public class SmsAdminServiceImpl implements SmsAdminService {
         Client client = ClientBuilder.newClient();
         try {
             JSONObject callbackReference = new JSONObject()
-                    .put("notifyURL", sp.smsdrcallbackurl);
+                    .put("notifyURL", callbackUrl);
             JSONObject subscription = new JSONObject()
                     .put("callbackReference", callbackReference);
             JSONObject body = new JSONObject()

--- a/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
+++ b/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
@@ -40,6 +40,73 @@ public class SmsAdminServiceImpl implements SmsAdminService {
     }
 
     @Override
+    public JSONObject getBalanceSummary() {
+        JSONObject contracts = getContracts();
+        if (!contracts.optBoolean("success", false)) {
+            return contracts; // propage l'erreur (token, http, code Orange...)
+        }
+        JSONArray items = new JSONArray();
+        long[] total = { 0L };
+        boolean[] found = { false };
+        collectUnits(contracts.opt("data"), items, total, found);
+
+        JSONObject result = new JSONObject()
+                .put("success", true)
+                .put("found", found[0])
+                .put("totalUnits", total[0])
+                .put("items", items);
+        if (!found[0]) {
+            // Format inattendu : on renvoie le brut pour diagnostic.
+            result.put("raw", contracts.opt("data"));
+        }
+        return result;
+    }
+
+    /** Parcourt récursivement la réponse contrats pour additionner les unités. */
+    private void collectUnits(Object node, JSONArray items, long[] total, boolean[] found) {
+        if (node instanceof JSONObject) {
+            JSONObject obj = (JSONObject) node;
+            Long units = extractUnits(obj);
+            if (units != null) {
+                found[0] = true;
+                total[0] += units;
+                items.put(new JSONObject()
+                        .put("units", units)
+                        .put("country", obj.optString("country", ""))
+                        .put("service", obj.optString("service", ""))
+                        .put("expiration", obj.has("expirationDate") ? obj.optString("expirationDate", "")
+                                : obj.optString("expiration", "")));
+            }
+            for (String key : obj.keySet()) {
+                collectUnits(obj.opt(key), items, total, found);
+            }
+        } else if (node instanceof JSONArray) {
+            JSONArray arr = (JSONArray) node;
+            for (int i = 0; i < arr.length(); i++) {
+                collectUnits(arr.opt(i), items, total, found);
+            }
+        }
+    }
+
+    private Long extractUnits(JSONObject obj) {
+        String[] keys = { "availableUnits", "remainingUnits", "remaining", "units", "availableUnit" };
+        for (String k : keys) {
+            if (obj.has(k)) {
+                try {
+                    return obj.getLong(k);
+                } catch (Exception e) {
+                    try {
+                        return (long) Double.parseDouble(obj.getString(k));
+                    } catch (Exception ignore) {
+                        // clé présente mais non numérique : on continue
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
     public JSONObject getStatistics() {
         return doGet(sp.pathsmsapiadminbaseurl + "/statistics", "statistiques");
     }
@@ -68,8 +135,7 @@ public class SmsAdminServiceImpl implements SmsAdminService {
             JSONObject callbackReference = new JSONObject()
                     .put("notifyURL", sp.smsdrcallbackurl);
             JSONObject subscription = new JSONObject()
-                    .put("callbackReference", callbackReference)
-                    .put("filterCriteria", "DR");
+                    .put("callbackReference", callbackReference);
             JSONObject body = new JSONObject()
                     .put("deliveryReceiptSubscription", subscription);
 

--- a/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
+++ b/src/main/java/rest/service/impl/SmsAdminServiceImpl.java
@@ -1,0 +1,176 @@
+package rest.service.impl;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import rest.service.SmsAdminService;
+import rest.service.SmsService;
+import util.AppParameters;
+import util.OrangeSmsResult;
+
+/**
+ * Implémentation des appels d'administration Orange (solde, statistiques,
+ * achats, souscriptions Delivery Receipt). Réutilise le token géré par
+ * {@link SmsService} et normalise les réponses (succès/erreur) via
+ * {@link OrangeSmsResult}.
+ *
+ * @author koben
+ */
+@Stateless
+public class SmsAdminServiceImpl implements SmsAdminService {
+
+    private static final Logger LOG = Logger.getLogger(SmsAdminServiceImpl.class.getName());
+    private final AppParameters sp = AppParameters.getInstance();
+    @EJB
+    private SmsService smsService;
+
+    @Override
+    public JSONObject getContracts() {
+        return doGet(sp.pathsmsapiadminbaseurl + "/contracts", "contrats");
+    }
+
+    @Override
+    public JSONObject getStatistics() {
+        return doGet(sp.pathsmsapiadminbaseurl + "/statistics", "statistiques");
+    }
+
+    @Override
+    public JSONObject getPurchaseOrders() {
+        return doGet(sp.pathsmsapiadminbaseurl + "/purchaseorders", "bons d'achat");
+    }
+
+    @Override
+    public JSONObject getDeliveryReceiptSubscriptions() {
+        return doGet(sp.pathsmsapisubscriptionurl, "souscriptions DR");
+    }
+
+    @Override
+    public JSONObject createDeliveryReceiptSubscription() {
+        if (StringUtils.isBlank(sp.smsdrcallbackurl)) {
+            return error("L'URL de callback DR (smsdrcallbackurl) n'est pas configurée", 0, null);
+        }
+        String token = smsService.getValidAccessToken();
+        if (StringUtils.isBlank(token)) {
+            return error("Token Orange indisponible", 0, null);
+        }
+        Client client = ClientBuilder.newClient();
+        try {
+            JSONObject callbackReference = new JSONObject()
+                    .put("notifyURL", sp.smsdrcallbackurl);
+            JSONObject subscription = new JSONObject()
+                    .put("callbackReference", callbackReference)
+                    .put("filterCriteria", "DR");
+            JSONObject body = new JSONObject()
+                    .put("deliveryReceiptSubscription", subscription);
+
+            WebTarget target = client.target(sp.pathsmsapisubscriptionurl);
+            Response response = target.request(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer ".concat(token))
+                    .post(Entity.entity(body.toString(), MediaType.APPLICATION_JSON_TYPE));
+            return normalize(response, "création souscription DR");
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Echec création souscription DR", e);
+            return error(e.getMessage(), 0, null);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Override
+    public JSONObject deleteDeliveryReceiptSubscription(String subscriptionId) {
+        if (StringUtils.isBlank(subscriptionId)) {
+            return error("Identifiant de souscription manquant", 0, null);
+        }
+        String token = smsService.getValidAccessToken();
+        if (StringUtils.isBlank(token)) {
+            return error("Token Orange indisponible", 0, null);
+        }
+        Client client = ClientBuilder.newClient();
+        try {
+            WebTarget target = client.target(sp.pathsmsapisubscriptionurl + "/" + subscriptionId);
+            Response response = target.request(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer ".concat(token))
+                    .delete();
+            return normalize(response, "suppression souscription DR");
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Echec suppression souscription DR", e);
+            return error(e.getMessage(), 0, null);
+        } finally {
+            client.close();
+        }
+    }
+
+    /** GET générique sur un endpoint admin Orange. */
+    private JSONObject doGet(String url, String libelle) {
+        String token = smsService.getValidAccessToken();
+        if (StringUtils.isBlank(token)) {
+            return error("Token Orange indisponible", 0, null);
+        }
+        Client client = ClientBuilder.newClient();
+        try {
+            WebTarget target = client.target(url);
+            Response response = target.request(MediaType.APPLICATION_JSON)
+                    .header("Authorization", "Bearer ".concat(token))
+                    .get();
+            return normalize(response, libelle);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Echec consultation " + libelle, e);
+            return error(e.getMessage(), 0, null);
+        } finally {
+            client.close();
+        }
+    }
+
+    /** Transforme une réponse Orange en {success, httpStatus, data|code|msg}. */
+    private JSONObject normalize(Response response, String libelle) {
+        int status = response.getStatus();
+        String body = response.hasEntity() ? response.readEntity(String.class) : null;
+        LOG.log(Level.INFO, "SMS admin [{0}] >>> http={1}, body={2}",
+                new Object[] { libelle, status, body });
+        if (status >= 200 && status < 300) {
+            JSONObject result = new JSONObject().put("success", true).put("httpStatus", status);
+            result.put("data", toJson(body));
+            return result;
+        }
+        OrangeSmsResult parsed = OrangeSmsResult.parse(status, body);
+        return error(parsed.getErrorMessage(), status, parsed.getErrorCode());
+    }
+
+    private JSONObject error(String msg, int httpStatus, String code) {
+        JSONObject result = new JSONObject()
+                .put("success", false)
+                .put("httpStatus", httpStatus)
+                .put("msg", msg != null ? msg : "Erreur inconnue");
+        if (code != null) {
+            result.put("code", code);
+        }
+        return result;
+    }
+
+    /** Parse le corps en JSONObject/JSONArray si possible, sinon renvoie la chaîne. */
+    private Object toJson(String body) {
+        if (StringUtils.isBlank(body)) {
+            return JSONObject.NULL;
+        }
+        String trimmed = body.trim();
+        try {
+            if (trimmed.startsWith("[")) {
+                return new JSONArray(trimmed);
+            }
+            return new JSONObject(trimmed);
+        } catch (Exception e) {
+            return body;
+        }
+    }
+
+}

--- a/src/main/java/rest/service/impl/SmsImpl.java
+++ b/src/main/java/rest/service/impl/SmsImpl.java
@@ -242,6 +242,18 @@ public class SmsImpl implements SmsService {
     }
 
     @Override
+    public String resendSMSById(String notificationId) {
+        Notification notification = em.find(Notification.class, notificationId);
+        if (notification == null) {
+            LOG.log(Level.WARNING, "Renvoi manuel ignore : notification introuvable {0}", notificationId);
+            return null;
+        }
+        // Renvoi forcé : on ne court-circuite pas sur le statut SENT.
+        sendSMS(notification);
+        return notification.getStatut() != null ? notification.getStatut().name() : null;
+    }
+
+    @Override
     public String getValidAccessToken() {
         SmsToken smsToken = getOrupdateSmsToken();
         return smsToken != null ? smsToken.getAccessToken() : null;

--- a/src/main/java/rest/service/impl/SmsImpl.java
+++ b/src/main/java/rest/service/impl/SmsImpl.java
@@ -13,8 +13,10 @@ import dal.enumeration.Statut;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.ejb.Asynchronous;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -27,12 +29,16 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import rest.service.SmsService;
 import util.Constant;
 import util.DateConverter;
 import util.AppParameters;
+import util.OrangeSmsClient;
+import util.OrangeSmsResult;
+import util.SmsDeliveryStatus;
 
 /**
  *
@@ -152,46 +158,200 @@ public class SmsImpl implements SmsService {
         }
 
         try {
-            Client client = ClientBuilder.newClient();
-            var message = notification.getMessage();
-
-            JSONObject jSONObject = new JSONObject();
-            JSONObject outboundSMSMessageRequest = new JSONObject();
-
-            outboundSMSMessageRequest.put("senderAddress", sp.senderAddress);
-            JSONObject outboundSMSTextMessage = new JSONObject();
-            outboundSMSTextMessage.put("message", message);
-            outboundSMSMessageRequest.put("outboundSMSTextMessage", outboundSMSTextMessage);
-            jSONObject.put("outboundSMSMessageRequest", outboundSMSMessageRequest);
-            WebTarget myResource = client.target(sp.pathsmsapisendmessageurl);
-            var bearer = "Bearer ".concat(smsToken.getAccessToken());
+            String message = notification.getMessage();
+            String bearer = smsToken.getAccessToken();
             Collection<NotificationClient> toClients = notification.getNotificationClients();
-            int count = 0;
+            int sent = 0;
+            int total = 0;
             for (NotificationClient toClient : toClients) {
                 TClient tc = toClient.getClient();
-                if (StringUtils.isNotEmpty(tc.getStrADRESSE())) {
-                    outboundSMSMessageRequest.put("address", "tel:+225" + tc.getStrADRESSE());
-                    Response response = myResource.request().header("Authorization", bearer)
-                            .post(Entity.entity(jSONObject.toString(), MediaType.APPLICATION_JSON_TYPE));
-                    if (response.getStatus() == 201) {
-                        toClient.setStatut(Statut.SENT);
-                        toClient.setSentAt(LocalDateTime.now());
-                        count++;
-
-                    }
+                if (tc == null || StringUtils.isEmpty(tc.getStrADRESSE())) {
+                    continue;
                 }
-
+                total++;
+                String address = "tel:+225" + tc.getStrADRESSE();
+                OrangeSmsResult result = OrangeSmsClient.send(sp.pathsmsapisendmessageurl, bearer, sp.senderAddress,
+                        address, message);
+                applyResultToClient(toClient, result);
+                LOG.log(Level.INFO, "sendSMS >>> notification={0}, client={1}, address={2}, {3}",
+                        new Object[] { notification.getId(), toClient.getId(), address, result.toLog() });
+                if (result.isAccepted()) {
+                    sent++;
+                }
             }
             notification.setNumberAttempt(notification.getNumberAttempt() + 1);
             notification.setModfiedAt(LocalDateTime.now());
+            updateNotificationStatut(notification, sent, total);
 
-            LOG.log(Level.INFO, "nombre de message envoye======{0}", count);
+            LOG.log(Level.INFO, "SMS acceptes par Orange ====== {0}/{1} (notification {2})",
+                    new Object[] { sent, total, notification.getId() });
             em.merge(notification);
 
         } catch (Exception ex) {
-            LOG.log(Level.SEVERE, null, ex);
+            LOG.log(Level.SEVERE, "Echec envoi SMS notification " + notification.getId(), ex);
         }
 
+    }
+
+    /** Reporte le résultat Orange sur le destinataire (statut, resourceURL, erreur). */
+    private void applyResultToClient(NotificationClient toClient, OrangeSmsResult result) {
+        toClient.setLastHttpStatus(result.getHttpStatus());
+        if (result.isAccepted()) {
+            toClient.setStatut(Statut.SENT);
+            toClient.setSentAt(LocalDateTime.now());
+            toClient.setResourceUrl(result.getResourceUrl());
+            toClient.setDeliveryStatus(SmsDeliveryStatus.ACCEPTED_BY_ORANGE);
+            toClient.setErrorCode(null);
+            toClient.setErrorMessage(null);
+        } else {
+            toClient.setErrorCode(result.getErrorCode());
+            toClient.setErrorMessage(result.getErrorMessage());
+        }
+    }
+
+    /** SENT si tous les destinataires ont été acceptés, LOCK après 3 tentatives. */
+    private void updateNotificationStatut(Notification notification, int sent, int total) {
+        if (total > 0 && sent == total) {
+            notification.setStatut(Statut.SENT);
+        } else if (notification.getNumberAttempt() >= 3) {
+            notification.setStatut(Statut.LOCK);
+        }
+    }
+
+    @Override
+    @Asynchronous
+    public void sendSMSByNotificationIdAsync(String notificationId) {
+        sendSMSById(notificationId);
+    }
+
+    @Override
+    public void sendSMSById(String notificationId) {
+        try {
+            Notification notification = em.find(Notification.class, notificationId);
+            if (notification == null) {
+                LOG.log(Level.WARNING, "Envoi SMS ignore : notification introuvable {0}", notificationId);
+                return;
+            }
+            if (notification.getStatut() == Statut.SENT) {
+                return;
+            }
+            sendSMS(notification);
+        } catch (Exception ex) {
+            LOG.log(Level.SEVERE, "Echec envoi SMS notification " + notificationId, ex);
+        }
+    }
+
+    @Override
+    public String getValidAccessToken() {
+        SmsToken smsToken = getOrupdateSmsToken();
+        return smsToken != null ? smsToken.getAccessToken() : null;
+    }
+
+    @Override
+    public boolean handleDeliveryReceipt(String rawPayload) {
+        if (StringUtils.isBlank(rawPayload)) {
+            return false;
+        }
+        try {
+            JSONObject json = new JSONObject(rawPayload);
+            JSONObject deliveryInfo = extractDeliveryInfo(json);
+            if (deliveryInfo == null) {
+                LOG.log(Level.WARNING, "DR ignore : format non reconnu {0}", rawPayload);
+                return false;
+            }
+            String address = deliveryInfo.optString("address", null);
+            String orangeStatus = deliveryInfo.optString("deliveryStatus", null);
+            String resourceUrl = deliveryInfo.optString("resourceURL", null);
+            String normalized = SmsDeliveryStatus.fromOrange(orangeStatus);
+
+            NotificationClient target = findClientForDeliveryReceipt(resourceUrl, address);
+            if (target == null) {
+                LOG.log(Level.WARNING, "DR sans destinataire correspondant (address={0}, resourceURL={1})",
+                        new Object[] { address, resourceUrl });
+                return false;
+            }
+            target.setDeliveryStatus(normalized);
+            if (SmsDeliveryStatus.DELIVERY_IMPOSSIBLE.equals(normalized)) {
+                target.setErrorMessage("Livraison impossible (Delivery Receipt Orange)");
+            }
+            em.merge(target);
+            LOG.log(Level.INFO, "DR applique : client={0}, address={1}, status={2}",
+                    new Object[] { target.getId(), address, normalized });
+            return true;
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, "Echec traitement Delivery Receipt", e);
+            return false;
+        }
+    }
+
+    /** Extrait l'objet deliveryInfo des différents formats de DR Orange. */
+    private JSONObject extractDeliveryInfo(JSONObject json) {
+        JSONObject container = json.optJSONObject("deliveryInfoNotification");
+        if (container == null) {
+            container = json;
+        }
+        Object di = container.opt("deliveryInfo");
+        if (di instanceof JSONObject) {
+            return (JSONObject) di;
+        }
+        if (di instanceof JSONArray && ((JSONArray) di).length() > 0) {
+            return ((JSONArray) di).optJSONObject(0);
+        }
+        JSONObject list = container.optJSONObject("deliveryInfoList");
+        if (list != null) {
+            Object dis = list.opt("deliveryInfo");
+            if (dis instanceof JSONObject) {
+                return (JSONObject) dis;
+            }
+            if (dis instanceof JSONArray && ((JSONArray) dis).length() > 0) {
+                return ((JSONArray) dis).optJSONObject(0);
+            }
+        }
+        return null;
+    }
+
+    /** Retrouve le destinataire concerné par un DR : par resourceURL sinon par numéro. */
+    private NotificationClient findClientForDeliveryReceipt(String resourceUrl, String address) {
+        if (StringUtils.isNotBlank(resourceUrl)) {
+            try {
+                List<NotificationClient> byUrl = em
+                        .createNamedQuery("NotificationClient.findByResourceUrl", NotificationClient.class)
+                        .setParameter("resourceUrl", resourceUrl).setMaxResults(1).getResultList();
+                if (!byUrl.isEmpty()) {
+                    return byUrl.get(0);
+                }
+            } catch (Exception ignore) {
+                // on tente le repli par numéro
+            }
+        }
+        if (StringUtils.isNotBlank(address)) {
+            try {
+                String number = normalizeMsisdn(address);
+                List<NotificationClient> byAddr = em.createQuery(
+                        "SELECT o FROM NotificationClient o WHERE o.client.strADRESSE = :num ORDER BY o.sentAt DESC",
+                        NotificationClient.class).setParameter("num", number).setMaxResults(1).getResultList();
+                if (!byAddr.isEmpty()) {
+                    return byAddr.get(0);
+                }
+            } catch (Exception ignore) {
+                // aucun destinataire trouvé
+            }
+        }
+        return null;
+    }
+
+    /** "tel:+2250709133208" -> "0709133208" (format stocké côté client). */
+    private String normalizeMsisdn(String address) {
+        String a = address.trim();
+        if (a.startsWith("tel:")) {
+            a = a.substring(4);
+        }
+        if (a.startsWith("+225")) {
+            a = a.substring(4);
+        } else if (a.startsWith("225")) {
+            a = a.substring(3);
+        }
+        return a;
     }
 
     @Override

--- a/src/main/java/rest/service/impl/SmsImpl.java
+++ b/src/main/java/rest/service/impl/SmsImpl.java
@@ -39,6 +39,7 @@ import util.AppParameters;
 import util.OrangeSmsClient;
 import util.OrangeSmsResult;
 import util.SmsDeliveryStatus;
+import util.SmsUserMessage;
 
 /**
  *
@@ -242,15 +243,44 @@ public class SmsImpl implements SmsService {
     }
 
     @Override
-    public String resendSMSById(String notificationId) {
+    public JSONObject resendSMSById(String notificationId) {
         Notification notification = em.find(Notification.class, notificationId);
         if (notification == null) {
             LOG.log(Level.WARNING, "Renvoi manuel ignore : notification introuvable {0}", notificationId);
-            return null;
+            return new JSONObject().put("success", false).put("statut", JSONObject.NULL)
+                    .put("userMessage", "Notification introuvable.");
         }
         // Renvoi forcé : on ne court-circuite pas sur le statut SENT.
         sendSMS(notification);
-        return notification.getStatut() != null ? notification.getStatut().name() : null;
+        return buildResendResult(notification);
+    }
+
+    /** Construit le compte rendu du renvoi à partir de l'état des destinataires. */
+    private JSONObject buildResendResult(Notification notification) {
+        boolean accepted = notification.getStatut() == Statut.SENT;
+        String statut = notification.getStatut() != null ? notification.getStatut().name() : null;
+        String code = null;
+        String orangeMessage = null;
+        if (!accepted) {
+            for (NotificationClient c : notification.getNotificationClients()) {
+                boolean clientOk = SmsDeliveryStatus.ACCEPTED_BY_ORANGE.equals(c.getDeliveryStatus())
+                        || c.getStatut() == Statut.SENT;
+                if (!clientOk && StringUtils.isNotBlank(c.getErrorMessage())) {
+                    code = c.getErrorCode();
+                    orangeMessage = c.getErrorMessage();
+                    break;
+                }
+            }
+        }
+        String userMessage = accepted
+                ? "SMS envoyé avec succès (accepté par Orange)."
+                : SmsUserMessage.friendly(code, orangeMessage);
+        return new JSONObject()
+                .put("success", accepted)
+                .put("statut", statut != null ? statut : JSONObject.NULL)
+                .put("code", code != null ? code : JSONObject.NULL)
+                .put("orangeMessage", orangeMessage != null ? orangeMessage : JSONObject.NULL)
+                .put("userMessage", userMessage);
     }
 
     @Override

--- a/src/main/java/util/AppParameters.java
+++ b/src/main/java/util/AppParameters.java
@@ -35,6 +35,12 @@ public final class AppParameters {
     public String pathsmsapitokenendpoint = "https://api.orange.com/oauth/v2/token";
     public String pathsmsapisendmessageurl = "https://api.orange.com/smsmessaging/v1/outbound/tel%3A%2B225000000/requests";
     public String senderAddress = "tel:+225000000";
+    // Consultation solde / contrats / statistiques (API Orange SMS admin).
+    public String pathsmsapiadminbaseurl = "https://api.orange.com/sms/admin/v1";
+    // Souscription aux Delivery Receipts (DR).
+    public String pathsmsapisubscriptionurl = "https://api.orange.com/smsmessaging/v1/outbound/tel%3A%2B225000000/subscriptions";
+    // URL publique du callback DR de Prestige (à renseigner pour activer les DR).
+    public String smsdrcallbackurl = "";
     public String accesstoken = "kqJ1LJkaFgeBCzsy2NCeiKPF95Mb", expiresin = "7776000";
     public String mobile = "", smtpHost = "smtp.gmail.com", protocol = "smtps";
     public String mailOfficine = "";
@@ -69,6 +75,18 @@ public final class AppParameters {
             pathsmsapitokenendpoint = prop.getProperty("pathsmsapitokenendpoint");
             pathsmsapisendmessageurl = prop.getProperty("pathsmsapisendmessageurl");
             senderAddress = prop.getProperty("senderAddress");
+            String adminBase = prop.getProperty("pathsmsapiadminbaseurl");
+            if (StringUtils.isNotEmpty(adminBase)) {
+                pathsmsapiadminbaseurl = adminBase;
+            }
+            String subscriptionUrl = prop.getProperty("pathsmsapisubscriptionurl");
+            if (StringUtils.isNotEmpty(subscriptionUrl)) {
+                pathsmsapisubscriptionurl = subscriptionUrl;
+            }
+            String drCallback = prop.getProperty("smsdrcallbackurl");
+            if (StringUtils.isNotEmpty(drCallback)) {
+                smsdrcallbackurl = drCallback;
+            }
             accesstoken = prop.getProperty("accesstoken");
             expiresin = prop.getProperty("expiresin");
             email = prop.getProperty("email");
@@ -120,6 +138,9 @@ public final class AppParameters {
             prop.setProperty("pathsmsapitokenendpoint", pathsmsapitokenendpoint);
             prop.setProperty("pathsmsapisendmessageurl", pathsmsapisendmessageurl);
             prop.setProperty("senderAddress", senderAddress);
+            prop.setProperty("pathsmsapiadminbaseurl", pathsmsapiadminbaseurl);
+            prop.setProperty("pathsmsapisubscriptionurl", pathsmsapisubscriptionurl);
+            prop.setProperty("smsdrcallbackurl", smsdrcallbackurl);
             prop.setProperty("expiresin", expiresin);
             prop.setProperty("accesstoken", accesstoken);
             prop.setProperty("mobile", mobile);

--- a/src/main/java/util/Constant.java
+++ b/src/main/java/util/Constant.java
@@ -104,6 +104,7 @@ public final class Constant {
     public static final String KEY_SMS_CLOTURE_CAISSE = "KEY_SMS_CLOTURE_CAISSE";
     public static final String KEY_SMS_AVOIR_IMMEDIAT = "KEY_SMS_AVOIR_IMMEDIAT";
     public static final String KEY_SMS_DR_CALLBACK_URL = "KEY_SMS_DR_CALLBACK_URL";
+    public static final String KEY_SMS_DR_CALLBACK_SECRET = "KEY_SMS_DR_CALLBACK_SECRET";
     public static final String KEY_SMS_MODIF_PRIX_VENTE = "KEY_SMS_MODIF_PRIX_VENTE";
     public static final String KEY_MAIL_CLOTURE_CAISSE = "KEY_MAIL_CLOTURE_CAISSE";
     public static final String KEY_HEURE_EMAIL = "KEY_HEURE_EMAIL";

--- a/src/main/java/util/Constant.java
+++ b/src/main/java/util/Constant.java
@@ -103,6 +103,7 @@ public final class Constant {
     public static final String GRANT_TYPE = "client_credentials";
     public static final String KEY_SMS_CLOTURE_CAISSE = "KEY_SMS_CLOTURE_CAISSE";
     public static final String KEY_SMS_AVOIR_IMMEDIAT = "KEY_SMS_AVOIR_IMMEDIAT";
+    public static final String KEY_SMS_DR_CALLBACK_URL = "KEY_SMS_DR_CALLBACK_URL";
     public static final String KEY_SMS_MODIF_PRIX_VENTE = "KEY_SMS_MODIF_PRIX_VENTE";
     public static final String KEY_MAIL_CLOTURE_CAISSE = "KEY_MAIL_CLOTURE_CAISSE";
     public static final String KEY_HEURE_EMAIL = "KEY_HEURE_EMAIL";

--- a/src/main/java/util/Constant.java
+++ b/src/main/java/util/Constant.java
@@ -102,6 +102,7 @@ public final class Constant {
     public static final String SMS_TOKEN_TYPE = "Bearer";
     public static final String GRANT_TYPE = "client_credentials";
     public static final String KEY_SMS_CLOTURE_CAISSE = "KEY_SMS_CLOTURE_CAISSE";
+    public static final String KEY_SMS_AVOIR_IMMEDIAT = "KEY_SMS_AVOIR_IMMEDIAT";
     public static final String KEY_SMS_MODIF_PRIX_VENTE = "KEY_SMS_MODIF_PRIX_VENTE";
     public static final String KEY_MAIL_CLOTURE_CAISSE = "KEY_MAIL_CLOTURE_CAISSE";
     public static final String KEY_HEURE_EMAIL = "KEY_HEURE_EMAIL";

--- a/src/main/java/util/OrangeSmsClient.java
+++ b/src/main/java/util/OrangeSmsClient.java
@@ -1,0 +1,62 @@
+package util;
+
+import java.util.concurrent.TimeUnit;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.json.JSONObject;
+
+/**
+ * Point d'entrée unique pour l'envoi d'un SMS via l'API Orange.
+ *
+ * Construit le corps {@code outboundSMSMessageRequest}, exécute l'appel HTTP,
+ * lit le corps de réponse et renvoie un {@link OrangeSmsResult} normalisé
+ * (code HTTP, resourceURL, code/message d'erreur). Mutualise le code jusqu'ici
+ * dupliqué entre {@code SmsImpl} et {@code NotificationScheduledService}.
+ *
+ * @author koben
+ */
+public final class OrangeSmsClient {
+
+    private OrangeSmsClient() {
+    }
+
+    /**
+     * Envoie un SMS à une adresse et retourne le résultat interprété.
+     *
+     * @param sendUrl       URL d'envoi Orange (sp.pathsmsapisendmessageurl)
+     * @param bearerToken   token d'accès OAuth2 (sans le préfixe "Bearer ")
+     * @param senderAddress adresse émettrice (sp.senderAddress)
+     * @param address       destinataire au format "tel:+225XXXXXXXX"
+     * @param message       contenu du SMS
+     */
+    public static OrangeSmsResult send(String sendUrl, String bearerToken, String senderAddress, String address,
+            String message) {
+        // Timeouts pour éviter de bloquer la transaction JTA si Orange est lent.
+        Client client = ClientBuilder.newBuilder()
+                .connectTimeout(10, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+        try {
+            JSONObject outboundSMSTextMessage = new JSONObject().put("message", message);
+            JSONObject outboundSMSMessageRequest = new JSONObject()
+                    .put("address", address)
+                    .put("senderAddress", senderAddress)
+                    .put("outboundSMSTextMessage", outboundSMSTextMessage);
+            JSONObject body = new JSONObject().put("outboundSMSMessageRequest", outboundSMSMessageRequest);
+
+            WebTarget target = client.target(sendUrl);
+            Response response = target.request()
+                    .header("Authorization", "Bearer ".concat(bearerToken))
+                    .post(Entity.entity(body.toString(), MediaType.APPLICATION_JSON_TYPE));
+            int status = response.getStatus();
+            String responseBody = response.hasEntity() ? response.readEntity(String.class) : null;
+            return OrangeSmsResult.parse(status, responseBody);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/src/main/java/util/OrangeSmsResult.java
+++ b/src/main/java/util/OrangeSmsResult.java
@@ -1,0 +1,241 @@
+package util;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Résultat normalisé d'un appel à l'API SMS Orange (envoi, token, admin).
+ *
+ * Centralise l'interprétation de la réponse Orange :
+ * <ul>
+ * <li>le code HTTP (201 = accepté, 4xx/5xx = erreur) ;</li>
+ * <li>le {@code resourceURL} retourné en cas de succès (utile pour le suivi /
+ * Delivery Receipt) ;</li>
+ * <li>le code d'erreur Orange ({@code messageId} de
+ * {@code serviceException}/{@code policyException}) et son libellé.</li>
+ * </ul>
+ *
+ * Référence : https://developer.orange.com/apis/sms-ci/api-reference
+ *
+ * @author koben
+ */
+public final class OrangeSmsResult {
+
+    private final int httpStatus;
+    private final boolean accepted;
+    private final String resourceUrl;
+    private final String errorCode;
+    private final String errorMessage;
+    private final String rawBody;
+
+    private OrangeSmsResult(int httpStatus, boolean accepted, String resourceUrl, String errorCode, String errorMessage,
+            String rawBody) {
+        this.httpStatus = httpStatus;
+        this.accepted = accepted;
+        this.resourceUrl = resourceUrl;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.rawBody = rawBody;
+    }
+
+    /**
+     * Construit un résultat à partir du code HTTP et du corps de réponse Orange.
+     */
+    public static OrangeSmsResult parse(int httpStatus, String body) {
+        boolean accepted = (httpStatus == 201);
+        String resourceUrl = null;
+        String errorCode = null;
+        String errorMessage = null;
+
+        if (StringUtils.isNotBlank(body)) {
+            try {
+                JSONObject json = new JSONObject(body);
+                if (accepted) {
+                    resourceUrl = extractResourceUrl(json);
+                } else {
+                    String[] err = extractError(json);
+                    errorCode = err[0];
+                    errorMessage = err[1];
+                }
+            } catch (Exception ignore) {
+                // corps non JSON : on garde le brut et le libellé HTTP
+            }
+        }
+
+        if (!accepted && StringUtils.isBlank(errorMessage)) {
+            errorMessage = httpLabel(httpStatus);
+        }
+        if (!accepted && StringUtils.isBlank(errorCode)) {
+            errorCode = "HTTP_" + httpStatus;
+        }
+
+        return new OrangeSmsResult(httpStatus, accepted, resourceUrl, errorCode, errorMessage, body);
+    }
+
+    private static String extractResourceUrl(JSONObject json) {
+        if (json.has("outboundSMSMessageRequest")) {
+            JSONObject req = json.optJSONObject("outboundSMSMessageRequest");
+            if (req != null) {
+                return req.optString("resourceURL", null);
+            }
+        }
+        return json.optString("resourceURL", null);
+    }
+
+    /**
+     * Extrait le couple [code, message] des structures d'erreur Orange :
+     * {@code requestError.serviceException}, {@code requestError.policyException}
+     * ou la forme OAuth {@code {"error":...,"error_description":...}}.
+     */
+    private static String[] extractError(JSONObject json) {
+        JSONObject exception = null;
+        if (json.has("requestError")) {
+            JSONObject requestError = json.optJSONObject("requestError");
+            if (requestError != null) {
+                if (requestError.has("serviceException")) {
+                    exception = requestError.optJSONObject("serviceException");
+                } else if (requestError.has("policyException")) {
+                    exception = requestError.optJSONObject("policyException");
+                }
+            }
+        }
+        if (exception != null) {
+            String messageId = exception.optString("messageId", null);
+            String text = resolveVariables(exception.optString("text", null),
+                    exception.optJSONArray("variables"));
+            String label = ORANGE_CODES.get(messageId);
+            String message = StringUtils.isNotBlank(label)
+                    ? label + (StringUtils.isNotBlank(text) ? " (" + text + ")" : "")
+                    : text;
+            return new String[] { messageId, message };
+        }
+        // Forme OAuth : token refusé / client non autorisé
+        if (json.has("error")) {
+            String code = json.optString("error", null);
+            String desc = json.optString("error_description", null);
+            return new String[] { code, StringUtils.isNotBlank(desc) ? desc : code };
+        }
+        // Forme alternative avec "fault"
+        if (json.has("fault")) {
+            JSONObject fault = json.optJSONObject("fault");
+            if (fault != null) {
+                return new String[] { fault.optString("code", null), fault.optString("faultstring", null) };
+            }
+        }
+        return new String[] { null, null };
+    }
+
+    /** Remplace %1, %2... dans le texte Orange par les valeurs de "variables". */
+    private static String resolveVariables(String text, JSONArray variables) {
+        if (StringUtils.isBlank(text) || variables == null) {
+            return text;
+        }
+        String result = text;
+        for (int i = 0; i < variables.length(); i++) {
+            result = result.replace("%" + (i + 1), String.valueOf(variables.opt(i)));
+        }
+        return result;
+    }
+
+    /** Libellé lisible d'un statut HTTP renvoyé par Orange. */
+    public static String httpLabel(int status) {
+        switch (status) {
+            case 200:
+                return "OK";
+            case 201:
+                return "Créé / accepté par Orange (pas encore livré au terminal)";
+            case 400:
+                return "Requête invalide (paramètre/sender/numéro incorrect)";
+            case 401:
+                return "Non authentifié : token expiré ou invalide";
+            case 403:
+                return "Interdit : droits insuffisants, sender non autorisé ou quota/solde épuisé";
+            case 404:
+                return "Ressource introuvable (URL d'envoi ou senderAddress incorrect)";
+            case 405:
+                return "Méthode HTTP non autorisée";
+            case 409:
+                return "Conflit";
+            case 429:
+                return "Trop de requêtes : quota/débit dépassé";
+            case 500:
+                return "Erreur interne Orange";
+            case 502:
+                return "Mauvaise passerelle Orange";
+            case 503:
+                return "Service Orange indisponible";
+            default:
+                return "Code HTTP " + status;
+        }
+    }
+
+    public int getHttpStatus() {
+        return httpStatus;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public String getResourceUrl() {
+        return resourceUrl;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public String getRawBody() {
+        return rawBody;
+    }
+
+    /** Trace courte et exploitable pour les logs. */
+    public String toLog() {
+        if (accepted) {
+            return "ACCEPTE(201) resourceURL=" + resourceUrl;
+        }
+        return "ECHEC(http=" + httpStatus + ", code=" + errorCode + ", msg=" + errorMessage + ")";
+    }
+
+    /**
+     * Catalogue des codes d'erreur Orange documentés
+     * (https://developer.orange.com/apis/sms-ci/api-reference) avec un libellé FR.
+     */
+    private static final Map<String, String> ORANGE_CODES = new HashMap<>();
+
+    static {
+        ORANGE_CODES.put("SVC0001", "Erreur de service générique");
+        ORANGE_CODES.put("SVC0002", "Valeur d'entrée invalide");
+        ORANGE_CODES.put("SVC0003", "Valeur d'entrée invalide pour un attribut");
+        ORANGE_CODES.put("SVC0004", "Aucune adresse destinataire valide fournie");
+        ORANGE_CODES.put("SVC0005", "Identifiant de corrélation déjà utilisé");
+        ORANGE_CODES.put("SVC0006", "Attribut(s) invalide(s)");
+        ORANGE_CODES.put("SVC0007", "Format d'adresse invalide");
+        ORANGE_CODES.put("SVC0008", "Empreinte (fingerprint) invalide");
+        ORANGE_CODES.put("SVC0270", "Type de Delivery Receipt non supporté");
+        ORANGE_CODES.put("POL0001", "Erreur de politique générique");
+        ORANGE_CODES.put("POL0002", "Échec de vérification de confidentialité");
+        ORANGE_CODES.put("POL0003", "Trop d'adresses destinataires");
+        ORANGE_CODES.put("POL0004", "Mode de facturation non supporté");
+        ORANGE_CODES.put("POL0005", "Trop de pièces dans le message");
+        ORANGE_CODES.put("POL0006", "Mode de notification non supporté");
+        ORANGE_CODES.put("POL0007", "Adresses de notification multiples non supportées");
+        ORANGE_CODES.put("POL0008", "Compte de charge invalide");
+        ORANGE_CODES.put("POL0009", "Quota dépassé ou abonné non provisionné pour le SMS");
+        ORANGE_CODES.put("POL0011", "Type de média non supporté");
+        ORANGE_CODES.put("POL0012", "Trop de destinataires");
+        ORANGE_CODES.put("POL0013", "Trop de messages envoyés (débit dépassé)");
+        ORANGE_CODES.put("POL0050", "Crédit/solde insuffisant pour envoyer le message");
+        ORANGE_CODES.put("POL1009", "Application non souscrite à l'API");
+        ORANGE_CODES.put("invalid_client", "Identifiants client (clientId/secret) invalides");
+        ORANGE_CODES.put("invalid_grant", "Autorisation refusée (grant invalide)");
+        ORANGE_CODES.put("invalid_token", "Token d'accès invalide ou expiré");
+    }
+}

--- a/src/main/java/util/SmsDeliveryStatus.java
+++ b/src/main/java/util/SmsDeliveryStatus.java
@@ -1,0 +1,54 @@
+package util;
+
+/**
+ * Statuts de livraison SMS, alignés sur les Delivery Receipts Orange.
+ *
+ * {@code ACCEPTED_BY_ORANGE} est notre statut local (réponse 201 à l'envoi) ;
+ * les autres correspondent aux valeurs {@code deliveryStatus} renvoyées par
+ * Orange dans les Delivery Receipts.
+ * Réf : https://developer.orange.com/apis/sms-ci/api-reference
+ *
+ * @author koben
+ */
+public final class SmsDeliveryStatus {
+
+    private SmsDeliveryStatus() {
+    }
+
+    /** Accepté par Orange (HTTP 201) - pas encore de confirmation terminal. */
+    public static final String ACCEPTED_BY_ORANGE = "ACCEPTED_BY_ORANGE";
+    /** Remis au réseau Orange. */
+    public static final String DELIVERED_TO_NETWORK = "DELIVERED_TO_NETWORK";
+    /** Livré sur le téléphone du destinataire (succès réel). */
+    public static final String DELIVERED_TO_TERMINAL = "DELIVERED_TO_TERMINAL";
+    /** Livraison impossible (numéro invalide, hors service...). */
+    public static final String DELIVERY_IMPOSSIBLE = "DELIVERY_IMPOSSIBLE";
+    /** Livraison incertaine. */
+    public static final String DELIVERY_UNCERTAIN = "DELIVERY_UNCERTAIN";
+    /** Message en attente de livraison (terminal injoignable temporairement). */
+    public static final String MESSAGE_WAITING = "MESSAGE_WAITING";
+
+    /**
+     * Convertit un {@code deliveryStatus} brut Orange (ex. "DeliveredToTerminal")
+     * vers notre constante normalisée.
+     */
+    public static String fromOrange(String orangeStatus) {
+        if (orangeStatus == null) {
+            return null;
+        }
+        switch (orangeStatus.trim()) {
+            case "DeliveredToNetwork":
+                return DELIVERED_TO_NETWORK;
+            case "DeliveredToTerminal":
+                return DELIVERED_TO_TERMINAL;
+            case "DeliveryImpossible":
+                return DELIVERY_IMPOSSIBLE;
+            case "DeliveryUncertain":
+                return DELIVERY_UNCERTAIN;
+            case "MessageWaiting":
+                return MESSAGE_WAITING;
+            default:
+                return orangeStatus.trim();
+        }
+    }
+}

--- a/src/main/java/util/SmsUserMessage.java
+++ b/src/main/java/util/SmsUserMessage.java
@@ -1,0 +1,67 @@
+package util;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Traduit un échec d'envoi SMS Orange (code + message technique) en un message
+ * d'action clair pour l'utilisateur final (caissier/pharmacien).
+ *
+ * Exemple : un 403 / POL0001 « You consumed all available units... » devient
+ * « Crédit SMS épuisé : rechargez votre bundle... ».
+ *
+ * @author koben
+ */
+public final class SmsUserMessage {
+
+    private SmsUserMessage() {
+    }
+
+    /**
+     * @param code         code d'erreur Orange (messageId ou HTTP_xxx), peut être null
+     * @param orangeMessage message technique Orange, peut être null
+     * @return message lisible et orienté action pour l'utilisateur
+     */
+    public static String friendly(String code, String orangeMessage) {
+        String c = StringUtils.trimToEmpty(code);
+        String m = StringUtils.lowerCase(StringUtils.trimToEmpty(orangeMessage));
+
+        // Crédit / bundle épuisé : cas le plus important côté métier.
+        if (m.contains("consumed all available units") || m.contains("buy a new bundle")
+                || m.contains("reactivate your contract") || m.contains("out of quota")
+                || m.contains("insufficient") || m.contains("credit")
+                || "POL0009".equalsIgnoreCase(c) || "POL0050".equalsIgnoreCase(c)) {
+            return "Crédit SMS épuisé : vous n'avez plus d'unités. "
+                    + "Veuillez recharger votre bundle SMS (sur developer.orange.com) "
+                    + "ou contacter Orange pour réactiver le contrat. Le SMS n'a pas été envoyé.";
+        }
+
+        // Authentification Orange (token / identifiants).
+        if ("HTTP_401".equalsIgnoreCase(c) || "invalid_token".equalsIgnoreCase(c)
+                || "invalid_client".equalsIgnoreCase(c) || "invalid_grant".equalsIgnoreCase(c)) {
+            return "Problème d'authentification avec Orange (token ou identifiants). "
+                    + "Veuillez contacter l'administrateur.";
+        }
+
+        // Débit / trop d'envois.
+        if ("HTTP_429".equalsIgnoreCase(c) || "POL0013".equalsIgnoreCase(c)) {
+            return "Trop d'envois en peu de temps. Veuillez réessayer dans un instant.";
+        }
+
+        // Numéro destinataire invalide.
+        if ("SVC0004".equalsIgnoreCase(c) || "SVC0007".equalsIgnoreCase(c)) {
+            return "Le numéro du destinataire est invalide ou mal formaté. Le SMS n'a pas été envoyé.";
+        }
+
+        // Sender non autorisé / interdiction générique.
+        if ("HTTP_403".equalsIgnoreCase(c)) {
+            return "Envoi refusé par Orange (sender non autorisé ou droits insuffisants). "
+                    + "Veuillez vérifier la configuration ou contacter l'administrateur.";
+        }
+
+        // Repli : on remonte le message Orange s'il existe, sinon un message générique.
+        if (StringUtils.isNotBlank(orangeMessage)) {
+            return "Échec de l'envoi : " + orangeMessage;
+        }
+        return "Échec de l'envoi du SMS" + (StringUtils.isNotBlank(c) ? " (code " + c + ")" : "") + ".";
+    }
+}

--- a/src/main/resources/db/migration/V6.2.6__sms_delivery_tracking.sql
+++ b/src/main/resources/db/migration/V6.2.6__sms_delivery_tracking.sql
@@ -1,0 +1,18 @@
+-- Suivi fin des envois SMS Orange (demande 2 : codes d'erreur + traçabilité,
+-- et base pour les Delivery Receipts - demande 4).
+-- On stocke par destinataire (notification_client) la ressource Orange et le
+-- dernier statut/erreur de livraison.
+
+ALTER TABLE `notification_client` ADD COLUMN IF NOT EXISTS `resource_url` VARCHAR(500) NULL DEFAULT NULL;
+ALTER TABLE `notification_client` ADD COLUMN IF NOT EXISTS `delivery_status` VARCHAR(40) NULL DEFAULT NULL;
+ALTER TABLE `notification_client` ADD COLUMN IF NOT EXISTS `error_code` VARCHAR(60) NULL DEFAULT NULL;
+ALTER TABLE `notification_client` ADD COLUMN IF NOT EXISTS `error_message` VARCHAR(500) NULL DEFAULT NULL;
+ALTER TABLE `notification_client` ADD COLUMN IF NOT EXISTS `last_http_status` INT NULL DEFAULT NULL;
+
+-- Paramètre d'activation de l'envoi immédiat des SMS d'avoir (demande 1).
+-- 1 = on tente l'envoi dès la création de la notification ; le job planifié
+-- reste le filet de rattrapage. Désactivable en passant la valeur à 0.
+INSERT INTO t_parameters (str_KEY, str_VALUE, str_DESCRIPTION, str_TYPE, str_STATUT, dt_CREATED)
+SELECT 'KEY_SMS_AVOIR_IMMEDIAT', '1',
+       'Envoi immediat des SMS de disponibilite d''avoir des la creation de la notification (0/1)', 'SYSTEM', 'enable', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM t_parameters WHERE str_KEY = 'KEY_SMS_AVOIR_IMMEDIAT');

--- a/src/main/resources/db/migration/V6.2.7__sms_dr_callback_url_param.sql
+++ b/src/main/resources/db/migration/V6.2.7__sms_dr_callback_url_param.sql
@@ -1,0 +1,8 @@
+-- URL publique du callback Delivery Receipt, parametrable depuis l'application
+-- (TParameters). Repli sur dicisms.properties (smsdrcallbackurl) si vide.
+-- Modifiable via l'ecran Notifications > Accuses de reception (DR).
+
+INSERT INTO t_parameters (str_KEY, str_VALUE, str_DESCRIPTION, str_TYPE, str_STATUT, dt_CREATED)
+SELECT 'KEY_SMS_DR_CALLBACK_URL', 'https://app.prestige3.com.ngrok.pro/prestige/api/v1/sms/dr-callback',
+       'URL publique appelee par Orange pour les accuses de reception SMS (Delivery Receipts)', 'SYSTEM', 'enable', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM t_parameters WHERE str_KEY = 'KEY_SMS_DR_CALLBACK_URL');

--- a/src/main/resources/db/migration/V6.2.8__sms_dr_callback_secret_param.sql
+++ b/src/main/resources/db/migration/V6.2.8__sms_dr_callback_secret_param.sql
@@ -1,0 +1,9 @@
+-- Jeton secret protegeant le callback Delivery Receipt (public sur Internet).
+-- Vide par defaut = protection desactivee. Renseigner une valeur depuis
+-- l'ecran Notifications > Accuses de reception (DR) pour activer la protection.
+-- Quand il est renseigne, Orange doit appeler /dr-callback?key=<secret>.
+
+INSERT INTO t_parameters (str_KEY, str_VALUE, str_DESCRIPTION, str_TYPE, str_STATUT, dt_CREATED)
+SELECT 'KEY_SMS_DR_CALLBACK_SECRET', '',
+       'Jeton secret du callback DR (parametre ?key=). Vide = protection desactivee.', 'SYSTEM', 'enable', NOW()
+WHERE NOT EXISTS (SELECT 1 FROM t_parameters WHERE str_KEY = 'KEY_SMS_DR_CALLBACK_SECRET');

--- a/src/main/webapp/general/app/controller/NotificationCtr.js
+++ b/src/main/webapp/general/app/controller/NotificationCtr.js
@@ -150,20 +150,80 @@ Ext.define('testextjs.controller.NotificationCtr', {
         const win = Ext.create('Ext.window.Window', {
             title: 'Accusés de réception SMS (Delivery Receipts)',
             modal: true,
-            width: 640,
-            height: 440,
-            layout: 'fit',
+            width: 680,
+            height: 480,
+            layout: 'anchor',
             bodyPadding: 10,
-            items: [{
+            items: [
+                {
+                    xtype: 'fieldcontainer',
+                    layout: 'hbox',
+                    anchor: '100%',
+                    items: [
+                        {
+                            xtype: 'textfield',
+                            itemId: 'drUrl',
+                            fieldLabel: 'URL callback',
+                            labelWidth: 80,
+                            flex: 1,
+                            emptyText: 'https://votre-domaine/prestige/api/v1/sms/dr-callback'
+                        },
+                        {
+                            xtype: 'button',
+                            text: 'Enregistrer l\'URL',
+                            margin: '0 0 0 6',
+                            handler: function () {
+                                const url = win.down('#drUrl').getValue();
+                                win.setLoading('Enregistrement...');
+                                Ext.Ajax.request({
+                                    url: '../api/v1/sms/dr-callback-url',
+                                    method: 'POST',
+                                    jsonData: {url: url},
+                                    callback: function (o, s, response) {
+                                        win.setLoading(false);
+                                        let r = {};
+                                        try {
+                                            r = Ext.decode(response.responseText);
+                                        } catch (ex) {
+                                            r = {};
+                                        }
+                                        Ext.Msg.alert('URL callback DR', r.msg || (r.success ? 'Enregistré.' : 'Echec.'));
+                                    }
+                                });
+                            }
+                        }
+                    ]
+                },
+                {
                     xtype: 'textarea',
                     itemId: 'drOutput',
+                    anchor: '100% -34',
                     readOnly: true,
-                    value: 'Utilisez les boutons ci-dessous.\n\n'
-                            + '- "Créer la souscription" active l\'envoi des accusés vers Prestige '
-                            + '(nécessite que l\'URL de callback publique soit configurée côté serveur : smsdrcallbackurl).\n'
+                    value: 'Renseignez l\'URL publique de callback ci-dessus puis "Enregistrer l\'URL".\n\n'
+                            + '- "Créer la souscription" active l\'envoi des accusés Orange vers Prestige.\n'
                             + '- "Lister" affiche les souscriptions existantes.\n'
                             + '- "Supprimer" retire une souscription via son identifiant.'
-                }],
+                }
+            ],
+            listeners: {
+                afterrender: function () {
+                    Ext.Ajax.request({
+                        url: '../api/v1/sms/dr-callback-url',
+                        method: 'GET',
+                        success: function (response) {
+                            let r = {};
+                            try {
+                                r = Ext.decode(response.responseText);
+                            } catch (ex) {
+                                r = {};
+                            }
+                            if (r.url) {
+                                win.down('#drUrl').setValue(r.url);
+                            }
+                        }
+                    });
+                }
+            },
             buttons: [
                 {
                     text: 'Créer la souscription',

--- a/src/main/webapp/general/app/controller/NotificationCtr.js
+++ b/src/main/webapp/general/app/controller/NotificationCtr.js
@@ -49,6 +49,10 @@ Ext.define('testextjs.controller.NotificationCtr', {
         {
             ref: 'dtEnd',
             selector: 'menunotification #dtEnd'
+        },
+        {
+            ref: 'smsSoldeLabel',
+            selector: 'menunotification #smsSoldeLabel'
         }
 
     ],
@@ -89,8 +93,130 @@ Ext.define('testextjs.controller.NotificationCtr', {
             },
             'menunotification #addBtn': {
                 click: this.onAddClick
+            },
+            'menunotification #refreshSolde': {
+                click: this.loadSolde
+            },
+            'menunotification #drBtn': {
+                click: this.onDrClick
             }
 
+        });
+    },
+
+    loadSolde: function () {
+        const me = this;
+        const label = me.getSmsSoldeLabel();
+        if (label) {
+            label.setText('chargement...');
+        }
+        Ext.Ajax.request({
+            url: '../api/v1/sms/solde',
+            method: 'GET',
+            success: function (response) {
+                let res = {};
+                try {
+                    res = Ext.decode(response.responseText);
+                } catch (ex) {
+                    res = {};
+                }
+                if (!label) {
+                    return;
+                }
+                if (res.success && res.found) {
+                    const total = res.totalUnits;
+                    const color = (total <= 0) ? 'red' : (total < 50 ? '#e69500' : 'green');
+                    let txt = '<span style="color:' + color + ';font-weight:bold;">' + total + ' unité(s)</span>';
+                    if (total <= 0) {
+                        txt += ' <span style="color:red;">- rechargez votre bundle SMS</span>';
+                    }
+                    label.setText(txt);
+                } else if (res.success && !res.found) {
+                    label.setText('<span style="color:#e69500;">solde indisponible (format Orange inattendu)</span>');
+                } else {
+                    label.setText('<span style="color:red;">' + (res.msg || res.userMessage || 'indisponible') + '</span>');
+                }
+            },
+            failure: function () {
+                if (label) {
+                    label.setText('<span style="color:red;">erreur serveur</span>');
+                }
+            }
+        });
+    },
+
+    onDrClick: function () {
+        const me = this;
+        const win = Ext.create('Ext.window.Window', {
+            title: 'Accusés de réception SMS (Delivery Receipts)',
+            modal: true,
+            width: 640,
+            height: 440,
+            layout: 'fit',
+            bodyPadding: 10,
+            items: [{
+                    xtype: 'textarea',
+                    itemId: 'drOutput',
+                    readOnly: true,
+                    value: 'Utilisez les boutons ci-dessous.\n\n'
+                            + '- "Créer la souscription" active l\'envoi des accusés vers Prestige '
+                            + '(nécessite que l\'URL de callback publique soit configurée côté serveur : smsdrcallbackurl).\n'
+                            + '- "Lister" affiche les souscriptions existantes.\n'
+                            + '- "Supprimer" retire une souscription via son identifiant.'
+                }],
+            buttons: [
+                {
+                    text: 'Créer la souscription',
+                    iconCls: 'addicon',
+                    handler: function () {
+                        me.drRequest(win, 'POST', '../api/v1/sms/dr-subscriptions', 'Création de la souscription DR');
+                    }
+                },
+                {
+                    text: 'Lister',
+                    iconCls: 'searchicon',
+                    handler: function () {
+                        me.drRequest(win, 'GET', '../api/v1/sms/dr-subscriptions', 'Souscriptions DR');
+                    }
+                },
+                {
+                    text: 'Supprimer...',
+                    handler: function () {
+                        Ext.Msg.prompt('Supprimer une souscription', 'Identifiant de la souscription :', function (btn, id) {
+                            if (btn === 'ok' && id) {
+                                me.drRequest(win, 'DELETE', '../api/v1/sms/dr-subscriptions/' + encodeURIComponent(id),
+                                        'Suppression de la souscription DR');
+                            }
+                        });
+                    }
+                },
+                {
+                    text: 'Fermer',
+                    handler: function () {
+                        win.close();
+                    }
+                }
+            ]
+        });
+        win.show();
+    },
+
+    drRequest: function (win, method, url, label) {
+        const output = win.down('#drOutput');
+        win.setLoading('Traitement...');
+        Ext.Ajax.request({
+            url: url,
+            method: method,
+            callback: function (options, success, response) {
+                win.setLoading(false);
+                let pretty = response.responseText;
+                try {
+                    pretty = JSON.stringify(Ext.decode(response.responseText), null, 2);
+                } catch (ex) {
+                    // on garde le texte brut
+                }
+                output.setValue(label + ' (HTTP ' + response.status + ') :\n\n' + pretty);
+            }
         });
     },
 
@@ -163,6 +289,7 @@ Ext.define('testextjs.controller.NotificationCtr', {
     doInitStore: function () {
         const me = this;
         me.doSearch();
+        me.loadSolde();
 
     },
     onReady: function () {

--- a/src/main/webapp/general/app/controller/NotificationCtr.js
+++ b/src/main/webapp/general/app/controller/NotificationCtr.js
@@ -83,7 +83,8 @@ Ext.define('testextjs.controller.NotificationCtr', {
              
              */
             "menunotification gridpanel actioncolumn": {
-                editer: this.toItem
+                editer: this.toItem,
+                renvoyer: this.onRenvoyer
 
             },
             'menunotification #addBtn': {
@@ -102,6 +103,41 @@ Ext.define('testextjs.controller.NotificationCtr', {
 
         Ext.create('testextjs.view.notification.NotificationForm', {data: record, grid: view}).show();
 
+    },
+
+    onRenvoyer: function (view, rowIndex, colIndex, item, e, record) {
+        const me = this;
+        const id = record.get('id');
+        Ext.Msg.confirm('Renvoi SMS', 'Renvoyer ce SMS maintenant ?', function (btn) {
+            if (btn !== 'yes') {
+                return;
+            }
+            const grid = me.getMenunotificationGrid();
+            grid.setLoading('Renvoi en cours...');
+            Ext.Ajax.request({
+                url: '../api/v1/notifications/' + encodeURIComponent(id) + '/resend',
+                method: 'POST',
+                success: function (response) {
+                    grid.setLoading(false);
+                    let res = {};
+                    try {
+                        res = Ext.decode(response.responseText);
+                    } catch (ex) {
+                        res = {};
+                    }
+                    if (res.success) {
+                        Ext.Msg.alert('Renvoi SMS', res.msg || 'SMS accepté par Orange (201)');
+                    } else {
+                        Ext.Msg.alert('Renvoi SMS', res.msg || 'Le renvoi a échoué.');
+                    }
+                    grid.getStore().reload();
+                },
+                failure: function () {
+                    grid.setLoading(false);
+                    Ext.Msg.alert('Renvoi SMS', 'Erreur lors de la communication avec le serveur.');
+                }
+            });
+        });
     },
 
     doBeforechange: function (page, currentPage) {

--- a/src/main/webapp/general/app/controller/NotificationCtr.js
+++ b/src/main/webapp/general/app/controller/NotificationCtr.js
@@ -156,29 +156,38 @@ Ext.define('testextjs.controller.NotificationCtr', {
             bodyPadding: 10,
             items: [
                 {
+                    xtype: 'textfield',
+                    itemId: 'drUrl',
+                    fieldLabel: 'URL callback',
+                    labelWidth: 90,
+                    anchor: '100%',
+                    emptyText: 'https://votre-domaine/prestige/api/v1/sms/dr-callback'
+                },
+                {
                     xtype: 'fieldcontainer',
                     layout: 'hbox',
                     anchor: '100%',
                     items: [
                         {
                             xtype: 'textfield',
-                            itemId: 'drUrl',
-                            fieldLabel: 'URL callback',
-                            labelWidth: 80,
+                            itemId: 'drSecret',
+                            fieldLabel: 'Clé secrète',
+                            labelWidth: 90,
                             flex: 1,
-                            emptyText: 'https://votre-domaine/prestige/api/v1/sms/dr-callback'
+                            emptyText: 'laisser vide = protection désactivée'
                         },
                         {
                             xtype: 'button',
-                            text: 'Enregistrer l\'URL',
+                            text: 'Enregistrer URL + clé',
                             margin: '0 0 0 6',
                             handler: function () {
                                 const url = win.down('#drUrl').getValue();
+                                const secret = win.down('#drSecret').getValue();
                                 win.setLoading('Enregistrement...');
                                 Ext.Ajax.request({
                                     url: '../api/v1/sms/dr-callback-url',
                                     method: 'POST',
-                                    jsonData: {url: url},
+                                    jsonData: {url: url, secret: secret},
                                     callback: function (o, s, response) {
                                         win.setLoading(false);
                                         let r = {};
@@ -187,7 +196,7 @@ Ext.define('testextjs.controller.NotificationCtr', {
                                         } catch (ex) {
                                             r = {};
                                         }
-                                        Ext.Msg.alert('URL callback DR', r.msg || (r.success ? 'Enregistré.' : 'Echec.'));
+                                        Ext.Msg.alert('Callback DR', r.msg || (r.success ? 'Enregistré.' : 'Echec.'));
                                     }
                                 });
                             }
@@ -197,12 +206,14 @@ Ext.define('testextjs.controller.NotificationCtr', {
                 {
                     xtype: 'textarea',
                     itemId: 'drOutput',
-                    anchor: '100% -34',
+                    anchor: '100% -60',
                     readOnly: true,
-                    value: 'Renseignez l\'URL publique de callback ci-dessus puis "Enregistrer l\'URL".\n\n'
-                            + '- "Créer la souscription" active l\'envoi des accusés Orange vers Prestige.\n'
+                    value: 'Renseignez l\'URL publique et (optionnel) une clé secrète, puis "Enregistrer URL + clé".\n\n'
+                            + '- Si une clé est définie, Orange appellera /dr-callback?key=... et tout appel sans la bonne clé sera refusé.\n'
+                            + '- "Créer la souscription" active l\'envoi des accusés Orange vers Prestige (avec la clé).\n'
                             + '- "Lister" affiche les souscriptions existantes.\n'
-                            + '- "Supprimer" retire une souscription via son identifiant.'
+                            + '- "Supprimer" retire une souscription via son identifiant.\n\n'
+                            + 'Important : apres avoir change l\'URL ou la cle, recreez la souscription.'
                 }
             ],
             listeners: {
@@ -219,6 +230,9 @@ Ext.define('testextjs.controller.NotificationCtr', {
                             }
                             if (r.url) {
                                 win.down('#drUrl').setValue(r.url);
+                            }
+                            if (r.secret) {
+                                win.down('#drSecret').setValue(r.secret);
                             }
                         }
                     });

--- a/src/main/webapp/general/app/view/notification/Notification.js
+++ b/src/main/webapp/general/app/view/notification/Notification.js
@@ -270,6 +270,20 @@ Ext.define('testextjs.view.notification.Notification', {
 
                         },
                         {
+                            header: 'Statut',
+                            dataIndex: 'statut',
+                            flex: 0.3,
+                            renderer: function (v) {
+                                if (v === 'Envoyé') {
+                                    return '<span style="color:green;font-weight:bold;">' + v + '</span>';
+                                } else if (v) {
+                                    return '<span style="color:#e69500;font-weight:bold;">' + v + '</span>';
+                                }
+                                return v;
+                            }
+
+                        },
+                        {
                             header: 'Destinataire',
                             flex: 1,
                             dataIndex: 'userTo',
@@ -291,24 +305,24 @@ Ext.define('testextjs.view.notification.Notification', {
 
                             }
 
-                        }
+                        },
+                        {
+                            xtype: 'actioncolumn',
+                            header: 'Renvoyer',
+                            width: 70,
+                            align: 'center',
+                            sortable: false,
+                            menuDisabled: true,
+                            items: [{
+                                    icon: 'resources/images/icons/fam/rss_go.png',
+                                    tooltip: 'Renvoyer le SMS',
+                                    menuDisabled: true,
+                                    handler: function (view, rowIndex, colIndex, item, e, record, row) {
+                                        this.fireEvent('renvoyer', view, rowIndex, colIndex, item, e, record, row);
+                                    }
 
-                        /* , {
-                         xtype: 'actioncolumn',
-                         width: 30,
-                         sortable: false,
-                         menuDisabled: true,
-                         
-                         items: [{
-                         icon: 'resources/images/icons/fam/rss_go.png',
-                         tooltip: 'Renvoyer',
-                         menuDisabled: true,
-                         handler: function (view, rowIndex, colIndex, item, e, record, row) {
-                         this.fireEvent('editer', view, rowIndex, colIndex, item, e, record, row);
-                         }
-                         
-                         }]
-                         }*/
+                                }]
+                        }
                     ],
                     selModel: {
                         selType: 'cellmodel'

--- a/src/main/webapp/general/app/view/notification/Notification.js
+++ b/src/main/webapp/general/app/view/notification/Notification.js
@@ -229,6 +229,34 @@ Ext.define('testextjs.view.notification.Notification', {
                             iconCls: 'searchicon'
                         }
                     ]
+                },
+                {
+                    xtype: 'toolbar',
+                    dock: 'top',
+                    style: 'background:#eef6ff;',
+                    items: [
+                        {
+                            xtype: 'tbtext',
+                            text: '<b>Solde SMS :</b>'
+                        },
+                        {
+                            xtype: 'tbtext',
+                            itemId: 'smsSoldeLabel',
+                            text: 'cliquez sur Rafraîchir'
+                        },
+                        '->',
+                        {
+                            text: 'Rafraîchir le solde',
+                            itemId: 'refreshSolde',
+                            iconCls: 'searchicon'
+                        },
+                        {xtype: 'tbseparator'},
+                        {
+                            text: 'Accusés de réception (DR)',
+                            itemId: 'drBtn',
+                            tooltip: 'Gérer les accusés de réception Orange (Delivery Receipts)'
+                        }
+                    ]
                 }
 
             ],
@@ -293,10 +321,20 @@ Ext.define('testextjs.view.notification.Notification', {
 
                                 if (user !== '') {
                                     return user;
-                                } else if (data.clients.length > 0) {
+                                } else if (data.clients && data.clients.length > 0) {
 
                                     Ext.each(data.clients, function (us) {
-                                        user += us.firstName + " " + us.lastName + " au " + us.clientPhone + "<br>";
+                                        let dr = '';
+                                        if (us.deliveryStatus === 'DELIVERED_TO_TERMINAL') {
+                                            dr = ' <span style="color:green;">[Reçu]</span>';
+                                        } else if (us.deliveryStatus === 'DELIVERY_IMPOSSIBLE') {
+                                            dr = ' <span style="color:red;">[Non remis]</span>';
+                                        } else if (us.deliveryStatus === 'ACCEPTED_BY_ORANGE') {
+                                            dr = ' <span style="color:#0066cc;">[Accepté Orange]</span>';
+                                        } else if (us.deliveryStatus) {
+                                            dr = ' <span style="color:#e69500;">[' + us.deliveryStatus + ']</span>';
+                                        }
+                                        user += us.firstName + " " + us.lastName + " au " + us.clientPhone + dr + "<br>";
 
                                     });
                                 }


### PR DESCRIPTION
## Summary
This PR significantly refactors the SMS Orange integration to improve error handling, delivery tracking, and add administrative API support. The changes centralize SMS sending logic, normalize Orange API responses, and implement Delivery Receipt (DR) callback handling.

## Key Changes

### New Core Components
- **OrangeSmsResult**: Unified result parser for Orange API responses (HTTP status, resourceURL, error codes/messages). Handles multiple error formats (serviceException, policyException, OAuth, fault) and includes a catalog of Orange error codes with French labels.
- **OrangeSmsClient**: Single entry point for SMS sending that encapsulates HTTP request building, response parsing, and timeout management (10s connect, 30s read).
- **SmsDeliveryStatus**: Constants and converter for Orange delivery receipt statuses (ACCEPTED_BY_ORANGE, DELIVERED_TO_TERMINAL, DELIVERY_IMPOSSIBLE, etc.).
- **SmsAdminService & SmsAdminServiceImpl**: New service layer for Orange admin API operations (contracts/balance, statistics, purchase orders, DR subscription management).

### Enhanced SMS Sending (SmsImpl)
- Refactored `sendSMS()` to use `OrangeSmsClient` for all requests, eliminating code duplication
- Per-client tracking: stores resourceURL, delivery status, error code/message, and HTTP status
- Improved notification status logic: SENT only if all recipients accepted, LOCK after 3 failed attempts
- Added `sendSMSById()` and `sendSMSByNotificationIdAsync()` for on-demand async sending (e.g., immediate SMS for available orders)
- Centralized token management via `getValidAccessToken()`
- Enhanced logging with structured error information

### Delivery Receipt Handling
- New `handleDeliveryReceipt()` method to process Orange DR callbacks
- Supports multiple DR payload formats (deliveryInfoNotification wrapper, direct deliveryInfo array/object)
- Maps Orange delivery statuses to normalized constants
- Updates NotificationClient with final delivery status and error details

### Database Schema
- Added 5 new columns to `notification_client` table:
  - `resource_url`: Orange resource URL for tracking/DR correlation
  - `delivery_status`: Normalized delivery status from DR
  - `error_code`: Orange error code (SVCxxxx, POLxxxx, HTTP_xxx)
  - `error_message`: Human-readable error label
  - `last_http_status`: Last HTTP response code from Orange

### REST API
- New `SmsResource` endpoint (`v1/sms`) with:
  - `GET /balance`: SMS contract/balance info
  - `GET /statistics`: Usage statistics
  - `GET /purchase-orders`: Purchase history
  - `GET/POST/DELETE /dr-subscriptions`: DR subscription management
  - `POST /dr-callback`: Public callback endpoint for Orange DR notifications (exempted from auth filter)

### Job Scheduler Cleanup
- Removed SMS sending logic from `NotificationScheduledService`
- Now delegates to `SmsService.sendSMSById()` for cleaner separation of concerns
- Removed duplicate token management code

### Configuration
- Added new AppParameters for admin API base URL, DR subscription endpoint, and DR callback URL

## Implementation Details
- Orange error codes are mapped to French labels via static catalog in OrangeSmsResult
- Variable substitution in Orange error messages (%1, %2...) is resolved from the variables array
- HTTP timeouts prevent transaction blocking on slow Orange API responses
- DR callback always returns 204 (No Content) to prevent Orange re-emissions, even on processing errors
- Immediate SMS sending (e.g., for order availability) uses async method to avoid blocking user requests

https://claude.ai/code/session_01MTpeJZUB9JnG2SgBtak7Lv